### PR TITLE
Use getcol for chunks

### DIFF
--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -129,7 +129,6 @@ def plot_baseline_comparison_data(
             before_delays_i, interval=MinMaxInterval(), stretch=LogStretch()
         )
 
-
         im = ax3.pcolormesh(
             before_baseline_data.time,
             before_delays.delay,

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -85,7 +85,7 @@ def plot_baseline_comparison_data(
         norm = ImageNormalize(
             after_amp_stokesi, interval=ZScaleInterval(), stretch=SqrtStretch()
         )
-        cmap = plt.cm.binary_r
+        cmap = plt.cm.viridis
 
         fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(
             2, 2, figsize=(12, 10), sharex=True, sharey="row"

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -85,6 +85,7 @@ def plot_baseline_comparison_data(
         norm = ImageNormalize(
             after_amp_stokesi, interval=ZScaleInterval(), stretch=SqrtStretch()
         )
+        cmap = plt.cm.binary_r
 
         fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(
             2, 2, figsize=(10, 10), sharex=True, sharey="row"
@@ -94,6 +95,7 @@ def plot_baseline_comparison_data(
             before_baseline_data.freq_chan,
             before_amp_stokesi.T,
             norm=norm,
+            cmap=cmap,
         )
         ax1.set(
             ylabel=f"Frequency / {before_baseline_data.freq_chan.unit:latex_inline}",
@@ -104,6 +106,7 @@ def plot_baseline_comparison_data(
             after_baseline_data.freq_chan,
             after_amp_stokesi.T,
             norm=norm,
+            cmap=cmap,
         )
         ax2.set(
             ylabel=f"Frequency / {after_baseline_data.freq_chan.unit:latex_inline}",
@@ -125,11 +128,13 @@ def plot_baseline_comparison_data(
             before_delays_i, interval=MinMaxInterval(), stretch=LogStretch()
         )
 
+
         im = ax3.pcolormesh(
             before_baseline_data.time,
             before_delays.delay,
             before_delays_i.T,
             norm=delay_norm,
+            cmap=cmap,
         )
         ax3.set(ylabel="Delay / s", title="Before")
         ax4.pcolormesh(
@@ -137,6 +142,7 @@ def plot_baseline_comparison_data(
             after_delays.delay,
             after_delays_i.T,
             norm=delay_norm,
+            cmap=cmap,
         )
         ax4.set(ylabel="Delay / s", title="After")
         fig.colorbar(im, ax=ax4, label="Stokes I Amplitude / Jy")
@@ -152,7 +158,7 @@ def plot_baseline_comparison_data(
                 ax.plot(
                     baseline_data.time,
                     w_delays.w_delays[b_idx],
-                    color="k",
+                    color="tab:red",
                     linestyle="--",
                     label=f"Delay for {w_delays.object_name}",
                 )

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -88,7 +88,7 @@ def plot_baseline_comparison_data(
         cmap = plt.cm.binary_r
 
         fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(
-            2, 2, figsize=(10, 10), sharex=True, sharey="row"
+            2, 2, figsize=(12, 10), sharex=True, sharey="row"
         )
         im = ax1.pcolormesh(
             before_baseline_data.time,
@@ -112,7 +112,8 @@ def plot_baseline_comparison_data(
             ylabel=f"Frequency / {after_baseline_data.freq_chan.unit:latex_inline}",
             title="After",
         )
-        fig.colorbar(im, ax=ax2, label="Stokes I Amplitude / Jy")
+        for ax in (ax1, ax2):
+            fig.colorbar(im, ax=ax, label="Stokes I Amplitude / Jy")
 
         # TODO: Move these delay calculations outside of the plotting function
         # And here we calculate the delay information
@@ -145,7 +146,8 @@ def plot_baseline_comparison_data(
             cmap=cmap,
         )
         ax4.set(ylabel="Delay / s", title="After")
-        fig.colorbar(im, ax=ax4, label="Stokes I Amplitude / Jy")
+        for ax in (ax3, ax4):
+            fig.colorbar(im, ax=ax, label="Stokes I Amplitude / Jy")
 
         if w_delays is not None:
             for ax, baseline_data in zip(  # type:ignore[call-overload]
@@ -159,7 +161,7 @@ def plot_baseline_comparison_data(
                     baseline_data.time,
                     w_delays.w_delays[b_idx],
                     color="tab:red",
-                    linestyle="--",
+                    linestyle="-",
                     label=f"Delay for {w_delays.object_name}",
                 )
                 ax.legend()

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -205,14 +205,14 @@ def _get_data_chunk_from_main_table(
     upper_row = chunk_size
 
     while lower_row < table_length:
-        rows: list[dict[str, Any]] = ms_table[lower_row:upper_row]
-
-        data = _list_to_array(list_of_rows=rows, key=data_column)
-        flags = _list_to_array(list_of_rows=rows, key="FLAG")
-        uvws = _list_to_array(list_of_rows=rows, key="UVW")
-        time_centroid = _list_to_array(list_of_rows=rows, key="TIME_CENTROID")
-        ant_1 = _list_to_array(list_of_rows=rows, key="ANTENNA1")
-        ant_2 = _list_to_array(list_of_rows=rows, key="ANTENNA2")
+        data = ms_table.getcol(data_column, startrow=lower_row, nrow=chunk_size)
+        flags = ms_table.getcol("FLAG", startrow=lower_row, nrow=chunk_size)
+        uvws = ms_table.getcol("UVW", startrow=lower_row, nrow=chunk_size)
+        time_centroid = ms_table.getcol(
+            "TIME_CENTROID", startrow=lower_row, nrow=chunk_size
+        )
+        ant_1 = ms_table.getcol("ANTENNA1", startrow=lower_row, nrow=chunk_size)
+        ant_2 = ms_table.getcol("ANTENNA2", startrow=lower_row, nrow=chunk_size)
 
         yield DataChunkArray(
             data=data,

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -560,7 +560,7 @@ def _tukey_tractor(
 
         # Delay with the elevation of the target object
         # TODO: Allow elevation to be a user parameter
-        elevation_mask = w_delays.elevation < (0 * u.deg)
+        elevation_mask = w_delays.elevation < tukey_tractor_options.elevation_cut
         taper[elevation_mask[time_idx], :, :] = 1.0
 
         # TODO: Handle case of aliased delays
@@ -620,6 +620,8 @@ class TukeyTractorOptions:
     """apply the taper using the delay towards the target object."""
     target_object: str = "Sun"
     """The target object to apply the delay towards."""
+    elevation_cut: u.Quantity = 0 * u.deg
+    """The elevation cut-off for the target object. Defaults to 0 degrees."""
 
 
 def tukey_tractor(

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -559,7 +559,8 @@ def _tukey_tractor(
         taper = 1.0 - taper
 
         # Delay with the elevation of the target object
-        elevation_mask = w_delays.elevation < (-3 * u.deg)
+        # TODO: Allow elevation to be a user parameter
+        elevation_mask = w_delays.elevation < (0 * u.deg)
         taper[elevation_mask[time_idx], :, :] = 1.0
 
         # TODO: Handle case of aliased delays

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -618,7 +618,7 @@ class TukeyTractorOptions:
     """apply the taper using the delay towards the target object."""
     target_object: str = "Sun"
     """The target object to apply the delay towards."""
-    elevation_cut: u.Quantity = 0 * u.deg
+    elevation_cut: u.Quantity = -1 * u.deg
     """The elevation cut-off for the target object. Defaults to 0 degrees."""
 
 


### PR DESCRIPTION
After experimenting on MacOS, I found that using the casa-native `getcol` call was _way_ faster than the list iteration method.

Would be good to check this is true across all platforms.