### PR TITLE
Wrap in delay space the object and taper

### DIFF
--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -596,34 +596,34 @@ def _tukey_tractor(
         elevation_mask = w_delays.elevation < tukey_tractor_options.elevation_cut
         taper[elevation_mask[time_idx], :, :] = 1.0
 
-        # # Comput flags to ignore the objects delay crossing 0, Do
-        # # This by computing the taper towards the field and
-        # # see if there are any components of the two sets of tapers
-        # # that are not 1 (where 1 is 'no change').
-        # field_taper = tukey_taper(
-        #     x=delay_time.delay,
-        #     outer_width=tukey_tractor_options.outer_width / 4,
-        #     tukey_width=tukey_tractor_options.tukey_width,
-        #     tukey_x_offset=None,
-        # )
-        # # We need to account for no broadcasting when offset is None
-        # # as the returned shape is different
-        # field_taper = field_taper[None, :, None]
-        # field_taper = 1.0 - field_taper
-        # intersecting_taper = np.any(
-        #     np.reshape((taper != 1) & (field_taper != 1), (taper.shape[0], -1)), axis=1
-        # )
+        # Comput flags to ignore the objects delay crossing 0, Do
+        # This by computing the taper towards the field and
+        # see if there are any components of the two sets of tapers
+        # that are not 1 (where 1 is 'no change').
+        field_taper = tukey_taper(
+            x=delay_time.delay,
+            outer_width=tukey_tractor_options.outer_width / 4,
+            tukey_width=tukey_tractor_options.tukey_width,
+            tukey_x_offset=None,
+        )
+        # We need to account for no broadcasting when offset is None
+        # as the returned shape is different
+        field_taper = field_taper[None, :, None]
+        field_taper = 1.0 - field_taper
+        intersecting_taper = np.any(
+            np.reshape((taper != 1) & (field_taper != 1), (taper.shape[0], -1)), axis=1
+        )
         # taper[
         #     intersecting_taper &
         #     ~elevation_mask[time_idx] &
         #     ~ignore_wrapping_for
         # ] = 0.0
-        # # Update flags
-        # flags_to_return = np.zeros_like(data_chunk.masked_data.mask)
-        # flags_to_return[intersecting_taper] = True
-        # flags_to_return = ~np.isfinite(
-        #     data_chunk.masked_data.filled(np.nan)
-        #     ) | flags_to_return
+        # Update flags
+        flags_to_return = np.zeros_like(data_chunk.masked_data.mask)
+        flags_to_return[intersecting_taper] = True
+        flags_to_return = (
+            ~np.isfinite(data_chunk.masked_data.filled(np.nan)) | flags_to_return
+        )
 
     # Delay-time is a 3D array: (time, delay, pol)
     # Taper is 1D: (delay,)

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -654,7 +654,7 @@ class TukeyTractorOptions:
     """Measurement set to be modified"""
     outer_width: float = np.pi / 4
     """The start of the tapering in frequency space"""
-    tukey_width: float = 0.25
+    tukey_width: float = np.pi / 8
     """The width of the tapered region in frequency space"""
     data_column: str = "DATA"
     """The visibility column to modify"""
@@ -791,7 +791,7 @@ def get_parser() -> ArgumentParser:
     tukey_parser.add_argument(
         "--tukey-width",
         type=float,
-        default=0.25,
+        default=np.pi / 8,
         help="The Tukey width of the Tukey taper in radians",
     )
     tukey_parser.add_argument(

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -19,7 +19,7 @@ from tqdm.auto import tqdm
 from jolly_roger.delays import data_to_delay_time, delay_time_to_data
 from jolly_roger.logging import logger
 from jolly_roger.plots import plot_baseline_comparison_data
-from jolly_roger.utils import log_dataclass_attributes
+from jolly_roger.utils import log_dataclass_attributes, log_jolly_roger_version
 from jolly_roger.uvws import WDelays, get_object_delay_for_ms
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
@@ -693,7 +693,7 @@ def tukey_tractor(
     Args:
         tukey_tractor_options (TukeyTractorOptions): The settings to use during the taper, and measurement set to apply them to.
     """
-    logger.info("jolly-roger")
+    log_jolly_roger_version()
     log_dataclass_attributes(
         to_log=tukey_tractor_options, class_name="TukeyTaperOptions"
     )

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -75,10 +75,10 @@ def tukey_taper(
         x_freq = x_freq[:, None] - tukey_x_offset[None, :]
         from jolly_roger.wrap import symmetric_domain_wrap
 
-        x_freq = symmetric_domain_wrap(values=x_freq, upper_limit=np.max(x))
+        x_freq = symmetric_domain_wrap(values=x_freq, upper_limit=np.pi)
 
     taper = np.ones_like(x_freq)
-    logger.debug(f"{x_freq.shape=} {type(x_freq)=}")
+    # logger.debug(f"{x_freq.shape=} {type(x_freq)=}")
     # Fully zero region
     taper[np.abs(x_freq) > outer_width] = 0
 
@@ -540,22 +540,22 @@ def _tukey_tractor(
         # Calculate the offset account of nyquist sampling
         from jolly_roger.wrap import symmetric_domain_wrap
 
-        wrap_tukey_x_offset = symmetric_domain_wrap(
-            values=tukey_x_offset, upper_limit=np.max(delay_time.delay)
+        tukey_x_offset = symmetric_domain_wrap(
+            values=tukey_x_offset.value, upper_limit=np.max(delay_time.delay).value
         )
 
         # need to scale the x offsert to the -pi to pi
         # The delay should be symmetric
-        # tukey_x_offset = (
-        #     tukey_x_offset / (np.max(delay_time.delay) / np.pi).decompose()
-        # ).value
+        tukey_x_offset = (
+            tukey_x_offset / (np.max(delay_time.delay) / np.pi).decompose()
+        ).value
         # # logger.info(f"{tukey_x_offset=}")
 
     taper = tukey_taper(
         x=delay_time.delay,
         outer_width=tukey_tractor_options.outer_width,
         tukey_width=tukey_tractor_options.tukey_width,
-        tukey_x_offset=wrap_tukey_x_offset,
+        tukey_x_offset=tukey_x_offset,
     )
     if w_delays is not None:
         # The use of the `tukey_x_offset` changes the

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -19,6 +19,7 @@ from tqdm.auto import tqdm
 from jolly_roger.delays import data_to_delay_time, delay_time_to_data
 from jolly_roger.logging import logger
 from jolly_roger.plots import plot_baseline_comparison_data
+from jolly_roger.utils import log_dataclass_attributes
 from jolly_roger.uvws import WDelays, get_object_delay_for_ms
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
@@ -653,7 +654,7 @@ class TukeyTractorOptions:
     """Measurement set to be modified"""
     outer_width: float = np.pi / 4
     """The start of the tapering in frequency space"""
-    tukey_width: float = np.pi / 8
+    tukey_width: float = 0.25
     """The width of the tapered region in frequency space"""
     data_column: str = "DATA"
     """The visibility column to modify"""
@@ -693,7 +694,9 @@ def tukey_tractor(
         tukey_tractor_options (TukeyTractorOptions): The settings to use during the taper, and measurement set to apply them to.
     """
     logger.info("jolly-roger")
-    logger.info(f"Options: {tukey_tractor_options}")
+    log_dataclass_attributes(
+        to_log=tukey_tractor_options, class_name="TukeyTaperOptions"
+    )
 
     # acquire all the tables necessary to get unit information and data from
     open_ms_tables = get_open_ms_tables(
@@ -788,7 +791,7 @@ def get_parser() -> ArgumentParser:
     tukey_parser.add_argument(
         "--tukey-width",
         type=float,
-        default=np.pi / 8,
+        default=0.25,
         help="The Tukey width of the Tukey taper in radians",
     )
     tukey_parser.add_argument(
@@ -871,6 +874,7 @@ def cli() -> None:
             apply_towards_object=args.apply_towards_object,
             ignore_nyquist_zone=args.ignore_nyquist_zone,
         )
+
         tukey_tractor(tukey_tractor_options=tukey_tractor_options)
     else:
         parser.print_help()

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -665,7 +665,7 @@ class TukeyTractorOptions:
     dry_run: bool = False
     """Indicates whether the data will be written back to the measurement set"""
     make_plots: bool = False
-    """Create a small set of diagnostic plots"""
+    """Create a small set of diagnostic plots. This can be slow."""
     overwrite: bool = False
     """If the output column exists it will be overwritten"""
     chunk_size: int = 1000
@@ -819,7 +819,7 @@ def get_parser() -> ArgumentParser:
     tukey_parser.add_argument(
         "--make-plots",
         action="store_true",
-        help="If set, the Tukey tractor will make plots of the results",
+        help="If set, the Tukey tractor will make plots of the results. This can be slow.",
     )
     tukey_parser.add_argument(
         "--overwrite",

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -597,7 +597,7 @@ def _tukey_tractor(
         elevation_mask = w_delays.elevation < tukey_tractor_options.elevation_cut
         taper[elevation_mask[time_idx], :, :] = 1.0
 
-        # Comput flags to ignore the objects delay crossing 0, Do
+        # Compute flags to ignore the objects delay crossing 0, Do
         # This by computing the taper towards the field and
         # see if there are any components of the two sets of tapers
         # that are not 1 (where 1 is 'no change').

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -613,6 +613,7 @@ def _tukey_tractor(
         intersecting_taper = np.any(
             np.reshape((taper != 1) & (field_taper != 1), (taper.shape[0], -1)), axis=1
         )
+        # # Should the data need to be modified in conjunction with the flags
         # taper[
         #     intersecting_taper &
         #     ~elevation_mask[time_idx] &

--- a/jolly_roger/utils.py
+++ b/jolly_roger/utils.py
@@ -1,0 +1,21 @@
+"""Small helper utility functions"""
+
+from __future__ import annotations
+
+from dataclasses import is_dataclass
+from typing import Any
+
+from jolly_roger.logging import logger
+
+
+def log_dataclass_attributes(to_log: Any, class_name: str | None = None) -> None:
+    """Log the attributes and values from an Dataclass"""
+    if not is_dataclass(to_log):
+        return
+
+    if class_name:
+        logger.info(f"Settings for {class_name}")
+
+    for attribute in to_log.__annotations__:
+        value = to_log.__dict__[attribute]
+        logger.info(f"{attribute:<30} = {value}")

--- a/jolly_roger/utils.py
+++ b/jolly_roger/utils.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from dataclasses import is_dataclass
 from typing import Any
 
+from jolly_roger import __version__
 from jolly_roger.logging import logger
+
+
+def log_jolly_roger_version() -> None:
+    """Write out a jolly roger header to output"""
+    logger.info("Jolly-Roger: Flagging and Tapering")
+    logger.info(f"Version: {__version__}")
 
 
 def log_dataclass_attributes(to_log: Any, class_name: str | None = None) -> None:

--- a/jolly_roger/wrap.py
+++ b/jolly_roger/wrap.py
@@ -20,7 +20,6 @@ def symmetric_domain_wrap(
     Returns:
         NDArray[np.floating]: Values that have been mapped to the -upper_limit to upper_limit domain
     """
-
     # Calculate an appropriate domain mapping
     # The natural domain is going to be mapped
     # to -pi to pi.

--- a/jolly_roger/wrap.py
+++ b/jolly_roger/wrap.py
@@ -36,7 +36,7 @@ def symmetric_domain_wrap(
 
 def calculate_nyquist_zone(
     values: NDArray[np.floating], upper_limit: float
-) -> NDArray[int]:
+) -> NDArray[np.int_]:
     """Return the nyquist zone a value is in for a symmetric
     set of bounds around zero
 
@@ -45,7 +45,7 @@ def calculate_nyquist_zone(
         upper_limit (float): The upper bound to the symmetric domain around zero
 
     Returns:
-        NDArray[int]: The zones values correspond to
+        NDArray[np.int_]: The zones values correspond to
     """
     return np.array(
         np.floor((upper_limit + np.abs(values)) / (2.0 * upper_limit)) + 1, dtype=int

--- a/jolly_roger/wrap.py
+++ b/jolly_roger/wrap.py
@@ -1,0 +1,52 @@
+"""Helper utilities to deal with cyclic boundaries
+on data"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def symmetric_domain_wrap(
+    values: NDArray[np.floating], upper_limit: float
+) -> NDArray[np.floating]:
+    """Place a set of values into a cyclic domain that is
+    symmetric around zero.
+
+    Args:
+        values (NDArray[np.floating]): Values that need to be mapped into the cyclic domain
+        upper_limit (float): The upper bound of the symmetric cyclic domain
+
+    Returns:
+        NDArray[np.floating]: Values that have been mapped to the -upper_limit to upper_limit domain
+    """
+
+    # Calculate an appropriate domain mapping
+    # The natural domain is going to be mapped
+    # to -pi to pi.
+    domain_mapping = np.pi / upper_limit
+
+    real = np.cos(values * domain_mapping)
+    imag = np.sin(values * domain_mapping)
+
+    wrapped_values = real + 1j * imag
+
+    return np.angle(wrapped_values) / domain_mapping
+
+
+def calculate_nyquist_zone(
+    values: NDArray[np.floating], upper_limit: float
+) -> NDArray[int]:
+    """Return the nyquist zone a value is in for a symmetric
+    set of bounds around zero
+
+    Args:
+        values (NDArray[np.floating]): The values to calculate the zone for
+        upper_limit (float): The upper bound to the symmetric domain around zero
+
+    Returns:
+        NDArray[int]: The zones values correspond to
+    """
+    return np.array(
+        np.floor((upper_limit + np.abs(values)) / (2.0 * upper_limit)) + 1, dtype=int
+    )

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -8,6 +8,28 @@ import numpy as np
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
 
+def test_symmetric_domain_wrap_with_2d_arrays() -> None:
+    """Ensure mapping values to a periodic domain works for arrays"""
+
+    values = np.array([np.linspace(10, 40, 10), np.linspace(10, 40, 10)])
+    assert values.shape == (2, 10)
+
+    wrapped_values = symmetric_domain_wrap(values=values, upper_limit=60)
+    assert wrapped_values.shape == values.shape
+    assert np.all(np.isclose(wrapped_values, values))
+
+    # The addition of 120 is the size of the domain here
+    # and they should be wrapped back to the main map
+    larger_values = np.array(
+        [np.linspace(10, 40, 10), np.linspace(10 + 120, 40 + 120, 10)]
+    )
+    assert values.shape == (2, 10)
+
+    wrapped_values = symmetric_domain_wrap(values=larger_values, upper_limit=60)
+    assert wrapped_values.shape == values.shape
+    assert np.all(np.isclose(wrapped_values, values))
+
+
 def test_symmetric_domain_wrap() -> None:
     """Ensure mapping values to a periodic domain works"""
 

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1,0 +1,42 @@
+"""Tests to ensure correctness of the
+wrapping utilities"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
+
+
+def test_symmetric_domain_wrap() -> None:
+    """Ensure mapping values to a periodic domain works"""
+
+    values = np.linspace(10, 40, 10)
+
+    wrapped_values = symmetric_domain_wrap(values=values, upper_limit=60)
+    assert np.all(np.isclose(values, wrapped_values))
+
+    values = np.linspace(10, 40, 10)
+
+    # Domain size would be 120 values given the upper limit of 60
+    wrapped_values = symmetric_domain_wrap(values=values + 120, upper_limit=60)
+    assert np.all(np.isclose(values, wrapped_values))
+
+    values = np.linspace(10, 40, 10)
+
+    # Domain size would be 120 values given the upper limit of 60
+    wrapped_values = symmetric_domain_wrap(values=values + 2 * 120, upper_limit=60)
+    assert np.all(np.isclose(values, wrapped_values))
+
+
+def test_calculate_nyquist_zone() -> None:
+    """Match to the right zone"""
+    assert calculate_nyquist_zone(values=30, upper_limit=60) == 1
+    assert calculate_nyquist_zone(values=90, upper_limit=60) == 2
+    assert calculate_nyquist_zone(values=-30, upper_limit=60) == 1
+    assert calculate_nyquist_zone(values=-90, upper_limit=60) == 2
+
+    assert np.all(
+        calculate_nyquist_zone(values=np.array([-90, -30, 0, 30, 90]), upper_limit=60)
+        == np.array([2, 1, 1, 1, 2])
+    )


### PR DESCRIPTION
Here is a PR that attempts to handle the wrapping nature of the delay space we are tapering.

Specifically:
- map the objects actual delay to the sampled delay domain
- wrap the taper itself around the boundaries of the sampled delay domain
- apply taper only when object is above the horizon
- avoid tapering if the objects delay is too high (and wraps too many times for it to be a bother)
- avoid the tapering and apply flags if the apparent delay of the object is too close to the delay=0 