### PR TITLE
Wrap the object around periodic boundary

### DIFF
--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -191,7 +191,7 @@ def plot_baseline_comparison_data(
                         path_effects=[
                             pe.Stroke(
                                 linewidth=6, foreground="white"
-                            ),  # Inner line (the actual dashed line)
+                            ),  # Add some contrast to help read line stand out
                             pe.Normal(),
                         ],
                     )

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from jolly_roger.uvws import WDelays
+from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
 if TYPE_CHECKING:
     from jolly_roger.delays import DelayTime
@@ -149,20 +150,38 @@ def plot_baseline_comparison_data(
             fig.colorbar(im, ax=ax, label="Stokes I Amplitude / Jy")
 
         if w_delays is not None:
+            ant_1, ant_2 = before_baseline_data.ant_1, before_baseline_data.ant_2
+            b_idx = w_delays.b_map[ant_1, ant_2]
+            wrapped_w_delays = symmetric_domain_wrap(
+                values=w_delays.w_delays[b_idx].value,
+                upper_limit=np.max(after_delays.delay).value,
+            )
+            zones = calculate_nyquist_zone(
+                values=w_delays.w_delays[b_idx].value,
+                upper_limit=np.max(after_delays.delay).value,
+            )
+            # Final append is to capture the last zone in the
+            # time range
+            transitions = [*np.argwhere(np.diff(zones))[:, 0], len(zones)]
+
             for ax, baseline_data in zip(  # type:ignore[call-overload]
                 (ax3, ax4),
                 (before_baseline_data, after_baseline_data),
                 strict=True,
             ):
-                ant_1, ant_2 = baseline_data.ant_1, baseline_data.ant_2
-                b_idx = w_delays.b_map[ant_1, ant_2]
-                ax.plot(
-                    baseline_data.time,
-                    w_delays.w_delays[b_idx],
-                    color="tab:red",
-                    linestyle="-",
-                    label=f"Delay for {w_delays.object_name}",
-                )
+                start_idx = 0
+                for _zone_idx, end_idx in enumerate(transitions):
+                    object_slice = slice(start_idx, end_idx)
+                    start_idx = end_idx
+                    ax.plot(
+                        baseline_data.time[object_slice],
+                        wrapped_w_delays[object_slice],
+                        color="tab:red",
+                        linestyle="-",
+                        label=f"Delay for {w_delays.object_name}"
+                        if _zone_idx == 0
+                        else None,
+                    )
                 ax.legend()
 
         output_path = (

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -162,7 +162,7 @@ def plot_baseline_comparison_data(
             )
             # Final append is to capture the last zone in the
             # time range
-            transitions = [*np.argwhere(np.diff(zones))[:, 0], len(zones)]
+            transitions = [*np.argwhere(np.diff(zones) != 0)[:, 0], len(zones)]
 
             for ax, baseline_data in zip(  # type:ignore[call-overload]
                 (ax3, ax4),
@@ -171,8 +171,11 @@ def plot_baseline_comparison_data(
             ):
                 start_idx = 0
                 for _zone_idx, end_idx in enumerate(transitions):
-                    object_slice = slice(start_idx, end_idx)
-                    start_idx = end_idx
+                    # The np.diff results in offset indices, so shift
+                    # back the transition by 1
+                    object_slice = slice(start_idx, end_idx + 1)
+                    # and ensure non-overlapping line segments
+                    start_idx = end_idx + 1
                     ax.plot(
                         baseline_data.time[object_slice],
                         wrapped_w_delays[object_slice],
@@ -181,6 +184,7 @@ def plot_baseline_comparison_data(
                         label=f"Delay for {w_delays.object_name}"
                         if _zone_idx == 0
                         else None,
+                        lw=1 * (_zone_idx + 1),  # zone 0 means no line
                     )
                 ax.legend()
 

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -176,17 +176,26 @@ def plot_baseline_comparison_data(
                     object_slice = slice(start_idx, end_idx + 1)
                     # and ensure non-overlapping line segments
                     start_idx = end_idx + 1
+                    import matplotlib.patheffects as pe
+
                     ax.plot(
                         baseline_data.time[object_slice],
                         wrapped_w_delays[object_slice],
                         color="tab:red",
-                        linestyle="-",
+                        # linestyle="-",
                         label=f"Delay for {w_delays.object_name}"
                         if _zone_idx == 0
                         else None,
-                        lw=1 * (_zone_idx + 1),  # zone 0 means no line
+                        dashes=(2 * _zone_idx + 1, 2 * _zone_idx + 1),
+                        lw=4,
+                        path_effects=[
+                            pe.Stroke(
+                                linewidth=6, foreground="white"
+                            ),  # Inner line (the actual dashed line)
+                            pe.Normal(),
+                        ],
                     )
-                ax.legend()
+                ax.legend(loc="upper right")
 
         output_path = (
             output_dir


### PR DESCRIPTION
this PR fixes the case where the object being tracked wraps around the periodic boundary in order to avoid a straight jump through the data space. 

The line width also thickens to indicate a larger wrap count.