### PR TITLE
Initial checks to skip nulling, avoid unnecessary writebacks and attempt to null sidelobes

### DIFF
--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -92,7 +92,7 @@ def plot_baseline_comparison_data(
             if not after_amp_stokesi.mask.all()
             else before_amp_stokesi
         )
-        if not norm_plot_data.all():
+        if not norm_plot_data.mask.all():
             norm = ImageNormalize(
                 norm_plot_data,
                 interval=ZScaleInterval(),
@@ -100,6 +100,7 @@ def plot_baseline_comparison_data(
             )
         else:
             logger.warning("No valid data found. No attempt to normalise data.")
+
             norm = None
 
         cmap = plt.cm.viridis

--- a/jolly_roger/response.py
+++ b/jolly_roger/response.py
@@ -1,0 +1,69 @@
+"""Helper functions and utilities to assist with the management of sinc responses in delay space"""
+
+from __future__ import annotations
+
+import astropy.units as u
+import numpy as np
+from numpy.typing import NDArray
+
+from jolly_roger.logging import logger
+
+"""This section deals with attempting to anaylitically construct properties of an
+idealised sinc response from an impulse. The limits of normalised sinc response:
+
+>>> sin(pi * x) / (pi * x)
+
+spans +/- 1. If we can constructed the expected range in delay space we ought
+to be able to automatically set a taper width and predict the location of the
+N'th sidelobe.
+"""
+# TODO: The above needs some proper math refs to support. Got here through
+# through some reading and toying.
+
+
+def calculate_expected_sinc_width(
+    freqs: NDArray[np.floating] | u.Quantity,
+) -> u.Quantity:
+    """The expected width of a sinc response in delay space given a set of frequencies,
+
+    The return result is +/- from 0. In otherwords the domain of the normalised
+    sinc function is 2 * result. The width of the sinc response is determined by the
+    bandwidth of the frequencies.
+
+    Args:
+        freqs (NDArray[np.floating] | u.Quantity): The sampled frequencies. If units are not specified MHz are assumed.
+
+    Returns:
+        u.Quantity: The expected width of the sinc response
+    """
+    if not isinstance(freqs, u.Quantity):
+        freqs = freqs * u.MHz  # Assume MHz if no units are provided
+
+    bandwidth = np.max(freqs) - np.min(freqs)  # Calculate bandwidth in Hz
+    sinc_width = (
+        (1 / bandwidth).decompose().to("s")
+    )  # The width of the sinc response in seconds
+
+    logger.debug(f"Calculated expected sinc width: {sinc_width=} for {bandwidth=}")
+
+    return sinc_width
+
+
+def get_delay_of_nth_sidelobe(
+    n: int, sinc_width: u.Quantity | np.floating
+) -> u.Quantity:
+    """Calculate the expected delay of the N'th sidelobe of a sinc response given the width of the sinc response.
+
+    The N'th sidelobe is located at n * sinc_width. The first sidelobe is located at sinc_width, the second at 2 * sinc_width, and so on.
+
+    Args:
+        n (int): The order of the sidelobe (1 for first sidelobe, 2 for second, etc.)
+        sinc_width (u.Quantity | np.floating): The width of the sinc response in seconds. If no units are attached seconds are assumed.
+
+    Returns:
+        u.Quantity: The expected delay of the N'th sidelobe in seconds.
+    """
+    if not isinstance(sinc_width, u.Quantity):
+        sinc_width *= u.s
+
+    return sinc_width * (n + 0.5)

--- a/jolly_roger/response.py
+++ b/jolly_roger/response.py
@@ -54,7 +54,9 @@ def get_delay_of_nth_sidelobe(
 ) -> u.Quantity:
     """Calculate the expected delay of the N'th sidelobe of a sinc response given the width of the sinc response.
 
-    The N'th sidelobe is located at n * sinc_width. The first sidelobe is located at sinc_width, the second at 2 * sinc_width, and so on.
+    The main response is located at delay 0 seconds and ends at +/1 sinc_width. The peak position of the N'th sidelobe is:
+
+    >>> (n + 0.5) * sinc_width
 
     Args:
         n (int): The order of the sidelobe (1 for first sidelobe, 2 for second, etc.)

--- a/jolly_roger/response.py
+++ b/jolly_roger/response.py
@@ -44,7 +44,7 @@ def calculate_expected_sinc_width(
         (1 / bandwidth).decompose().to("s")
     )  # The width of the sinc response in seconds
 
-    logger.debug(f"Calculated expected sinc width: {sinc_width=} for {bandwidth=}")
+    logger.info(f"Calculated expected sinc width: {sinc_width=} for {bandwidth=}")
 
     return sinc_width
 
@@ -58,6 +58,8 @@ def get_delay_of_nth_sidelobe(
 
     >>> (n + 0.5) * sinc_width
 
+    For the special case of n=0, 0 seconds is returned, which is the location of the main response.
+
     Args:
         n (int): The order of the sidelobe (1 for first sidelobe, 2 for second, etc.)
         sinc_width (u.Quantity | np.floating): The width of the sinc response in seconds. If no units are attached seconds are assumed.
@@ -67,5 +69,8 @@ def get_delay_of_nth_sidelobe(
     """
     if not isinstance(sinc_width, u.Quantity):
         sinc_width *= u.s
+
+    if n == 0:
+        return 0 * u.s
 
     return sinc_width * (n + 0.5)

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -596,21 +596,28 @@ def _tukey_tractor(
     intersecting_taper = np.any(
         np.reshape((taper != 1) & (field_taper != 1), (taper.shape[0], -1)), axis=1
     )
-    
+
     # Here we consider what to do if want to compare brightness of the object in delay
-    # space is less than that of the field. If the object is not detected we ought to 
+    # space is less than that of the field. If the object is not detected we ought to
     # set the tape to 1 so the data are not modified
     if tukey_tractor_options.compare_to_field:
+        # The delay spectrum are complex quantities, and we need to compare
+        # the flux
         abs_delay_time = np.abs(delay_time.delay_time)
-        field_sum = np.sum(
-            abs_delay_time * (1. - field_taper), axis=1
+
+        # output of the field taper is constant over rows, so
+        # some broadcasting is needed to handle the array shapes
+        _field_taper = np.squeeze(field_taper)
+        field_sum = np.sum(abs_delay_time * (1.0 - _field_taper)[None, :, None], axis=1)
+        object_sum = np.sum(abs_delay_time * (1.0 - taper), axis=1)
+        flux_mask = np.any(
+            object_sum < tukey_tractor_options.compare_to_field * field_sum, axis=1
         )
-        object_sum = np.sum(
-            abs_delay_time * (1. - taper), axis=1
-        )
-        taper[object_sum < tukey_tractor_options.compare_to_field * field_sum] = 1.0
-    
-    
+
+        # For any element where there is not enough flux set the taper so
+        # it does not modify the data
+        taper[flux_mask] = 1.0
+
     # # Should the data need to be modified in conjunction with the flags
     # taper[
     #     intersecting_taper &
@@ -716,7 +723,7 @@ class TukeyTractorOptions(BaseOptions):
     max_workers: int = 1
     """The number of compute processes to establish. Each process gets chunk_size of rows. If max_worker==1 all work is performed in main thread."""
     compare_to_field: float | None = None
-    """Compare the source brightness in delay space to the field. If the source is fainter than the field multipled by this factor, do not taper. Defaults to None."""
+    """Compare the source brightness in delay space to the field. If the source is fainter than the field multiplied by this factor, do not taper. Defaults to None."""
 
 
 @dataclass(frozen=True)

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -596,6 +596,21 @@ def _tukey_tractor(
     intersecting_taper = np.any(
         np.reshape((taper != 1) & (field_taper != 1), (taper.shape[0], -1)), axis=1
     )
+    
+    # Here we consider what to do if want to compare brightness of the object in delay
+    # space is less than that of the field. If the object is not detected we ought to 
+    # set the tape to 1 so the data are not modified
+    if tukey_tractor_options.compare_to_field:
+        abs_delay_time = np.abs(delay_time.delay_time)
+        field_sum = np.sum(
+            abs_delay_time * (1. - field_taper), axis=1
+        )
+        object_sum = np.sum(
+            abs_delay_time * (1. - taper), axis=1
+        )
+        taper[object_sum < tukey_tractor_options.compare_to_field * field_sum] = 1.0
+    
+    
     # # Should the data need to be modified in conjunction with the flags
     # taper[
     #     intersecting_taper &
@@ -700,6 +715,8 @@ class TukeyTractorOptions(BaseOptions):
     """Flip the sign of UVWs (required for LOFAR)"""
     max_workers: int = 1
     """The number of compute processes to establish. Each process gets chunk_size of rows. If max_worker==1 all work is performed in main thread."""
+    compare_to_field: float | None = None
+    """Compare the source brightness in delay space to the field. If the source is fainter than the field multipled by this factor, do not taper. Defaults to None."""
 
 
 @dataclass(frozen=True)

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -563,6 +563,7 @@ def _tukey_tractor(
     # Since we want to dampen the target object we invert the taper.
     # By default the taper dampers outside the inner region.
     taper = 1.0 - taper
+    # taper shape is [chunk_size, no_channels, no_pols]
 
     # apply the flags to ignore the tapering if the object is larger
     # than one wrap away
@@ -588,10 +589,11 @@ def _tukey_tractor(
     # that are not 1 (where 1 is 'no change').
     field_taper = tukey_taper(
         x=delay_time.delay.to("s").value,
-        outer_width=tukey_tractor_options.outer_width_ns * 1e-9 / 4,
-        tukey_width=tukey_tractor_options.tukey_width_ns * 1e-9 / 4,
+        outer_width=tukey_tractor_options.outer_width_ns * 1e-9,
+        tukey_width=tukey_tractor_options.tukey_width_ns * 1e-9,
         tukey_x_offset=None,
     )
+    # field_taper.shape is [no_channels, ]
     # We need to account for no broadcasting when offset is None
     # as the returned shape is different
     field_taper = field_taper[None, :, None]
@@ -606,20 +608,24 @@ def _tukey_tractor(
     if tukey_tractor_options.compare_to_field:
         # The delay spectrum are complex quantities, and we need to compare
         # the flux
-        abs_delay_time = np.abs(delay_time.delay_time)
-
+        # Make a stokes I type spectrum
+        # logger.info(f"{delay_time.delay_time.shape=}")
+        abs_delay_time = np.abs(np.sum(delay_time.delay_time[..., [0, -1]], axis=-1))
         # output of the field taper is constant over rows, so
         # some broadcasting is needed to handle the array shapes
         _field_taper = np.squeeze(field_taper)
-        field_sum = np.sum(abs_delay_time * (1.0 - _field_taper)[None, :, None], axis=1)
-        object_sum = np.sum(abs_delay_time * (1.0 - taper), axis=1)
-        flux_mask = np.any(
-            object_sum < tukey_tractor_options.compare_to_field * field_sum, axis=1
-        )
+        field_stats = np.max(abs_delay_time * (1.0 - _field_taper)[None, :], axis=1)
+        object_stats = np.max(abs_delay_time * (1.0 - taper[..., 0]), axis=1)
+
+        # Depending on size of chunk this could be expensive
+        logger.debug("np.sum(_field_taper)=%f", np.sum(_field_taper))
+        logger.debug("np.sum(taper[0, :, 0])=%f", np.sum(taper[0, :, 0]))
+
+        flux_mask = object_stats < tukey_tractor_options.compare_to_field * field_stats
 
         # For any element where there is not enough flux set the taper so
         # it does not modify the data
-        taper[flux_mask] = 1.0
+        taper[flux_mask, :] = 1.0
 
     # # Should the data need to be modified in conjunction with the flags
     # taper[

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -495,12 +495,30 @@ def _get_baseline_time_indicies(
     return baseline_idx, time_idx
 
 
+@dataclass
+class TaperResult:
+    """Simple container to help ensure consistent and trackable behaviour
+    across levels
+    """
+
+    attached_payload: bool = False
+    """Indicates whether anything to do."""
+    taper: NDArray[np.floating] | None = None
+    """The taper to apply. If None nothing to do."""
+    update_flags: bool = False
+    """Indicates whether flags need to be updated"""
+    flags: NDArray[bool] | None = None
+    """The fupdated flags"""
+    delay_time: DelayTime | None = None
+    """The delay_time taper was constructede against"""
+
+
 def _tukey_tractor(
     data_chunk: DataChunk,
     tukey_tractor_options: TukeyTractorOptions,
     w_delays: WDelays,
     delay_time: DelayTime | None = None,
-) -> tuple[NDArray[np.float64], NDArray[np.bool_], DelayTime]:
+) -> TaperResult:
     """Compute a tukey taper for a dataset and then apply it
     to the dataset. Here the data corresponds to a (chan, time, pol)
     array. Data is not necessarily a single baseline.
@@ -517,8 +535,21 @@ def _tukey_tractor(
         delay_time (DelayTime | None, optional): Optional pre-computed DelayTime object.
 
     Returns:
-        tuple[DataChunk,NDArray[np.bool_],DelayTime]: Scaled complex visibilities, corresponding flags, and delays.
+        TaperResult: Scaled complex visibilities, corresponding flags, and delays.
     """
+
+    baseline_idx, time_idx = _get_baseline_time_indicies(
+        w_delays=w_delays, data_chunk=data_chunk
+    )
+
+    # Delay with the elevation of the target object
+    elevation_mask = w_delays.elevation < (
+        tukey_tractor_options.elevation_cut_deg * u.deg
+    )
+    # Bail out early if there is nothing that can be done with this source
+    if np.all(elevation_mask[time_idx]):
+        return TaperResult(attached_payload=False)
+
     if delay_time is None:
         delay_time = data_to_delay_time(data=data_chunk)
 
@@ -527,9 +558,6 @@ def _tukey_tractor(
     # towards the nominated object in the if below
     tukey_x_offset: u.Quantity = np.zeros_like(delay_time.delay)
 
-    baseline_idx, time_idx = _get_baseline_time_indicies(
-        w_delays=w_delays, data_chunk=data_chunk
-    )
     original_tukey_x_offset = w_delays.w_delays[baseline_idx, time_idx]
 
     # Make a copy for later use post wrapping
@@ -577,10 +605,6 @@ def _tukey_tractor(
     )
     taper[ignore_wrapping_for, :, :] = 1.0
 
-    # Delay with the elevation of the target object
-    elevation_mask = w_delays.elevation < (
-        tukey_tractor_options.elevation_cut_deg * u.deg
-    )
     taper[elevation_mask[time_idx], :, :] = 1.0
 
     # Compute flags to ignore the objects delay crossing 0, Do
@@ -640,7 +664,13 @@ def _tukey_tractor(
         ~np.isfinite(data_chunk.masked_data.filled(np.nan)) | flags_to_return
     )
 
-    return taper, flags_to_return, delay_time
+    return TaperResult(
+        attached_payload=True,
+        taper=taper,
+        update_flags=np.any(flags_to_return),
+        flags=flags_to_return,
+        delay_time=delay_time,
+    )
 
 
 def _apply_taper(
@@ -667,27 +697,75 @@ def _apply_taper(
     return tapered_data
 
 
+@dataclass
+class TaperedChunkResult:
+    """ "Simple container for the application of tapered data and associated
+    meta-data to write back to the MS
+    """
+
+    chunk_size: int
+    """The size of the chunk this result represents"""
+    nothing_to_do: bool = False
+    """Simple flag indicating this chunk contains nothing that needs updating so can be skipped"""
+    update_data: bool = False
+    """Indicates whether the data chunk needs to be written back"""
+    data_chunk: DataChunk | None = None
+    """The data to write back"""
+    update_flags: bool = False
+    """"Indicates whether the flags need to be written back to MS"""
+    flags: NDArray[bool] | None = None
+    """The flags to write back"""
+
+
 def _tukey_multi_tractor(
     data_chunk: DataChunk,
     tukey_tractor_options: TukeyTractorOptions,
     w_delays_list: list[WDelays],
-) -> tuple[DataChunk, NDArray[np.bool_]]:
-    # Initialise to None, then reuse to save on computation
+) -> TaperedChunkResult:
+    chunk_size = data_chunk.chunk_size
+
+    # Get the results for each object. Note reusing the delay_time object
+    # to avoid unnecessary recomputes. Also why the for loop and not list comphrension
     delay_time: DelayTime | None = None
-    taper_list: list[NDArray[np.float64]] = []
-    flag_list: list[NDArray[np.bool_]] = []
+    taper_results = []
     for w_delays in w_delays_list:
-        taper, flags_to_return, delay_time = _tukey_tractor(
+        taper_result = _tukey_tractor(
             data_chunk=data_chunk,
             tukey_tractor_options=tukey_tractor_options,
             w_delays=w_delays,
             delay_time=delay_time,
         )
-        taper_list.append(taper)
-        flag_list.append(flags_to_return)
+        delay_time = taper_result.delay_time
+        taper_results.append(taper_result)
 
-    combined_taper = np.min(taper_list, axis=0)
-    combined_flags = np.sum(flag_list, axis=0).astype(bool)
+    # Handle all the cases
+    if all(not taper_result.attached_payload for taper_result in taper_results):
+        return TaperedChunkResult(chunk_size=chunk_size, nothing_to_do=True)
+
+    # Throw away objects that are unnecessary in subsequent stages
+    taper_results = [
+        taper_result for taper_result in taper_results if taper_result.attached_payload
+    ]
+
+    combined_taper = np.min(
+        [
+            taper_result.taper
+            for taper_result in taper_results
+            if taper_result.taper is not None
+        ],
+        axis=0,
+    )
+
+    update_flag_list = [
+        taper_result.flags
+        for taper_result in taper_results
+        if taper_result.update_flags
+    ]
+    update_flags = len(update_flag_list) > 0
+
+    combined_flags = (
+        np.sum(update_flag_list, axis=0).astype(bool) if update_flags else None
+    )
 
     tapered_data = _apply_taper(
         data_chunk=data_chunk,
@@ -695,7 +773,14 @@ def _tukey_multi_tractor(
         taper=combined_taper,
     )
 
-    return tapered_data, combined_flags
+    return TaperedChunkResult(
+        chunk_size=chunk_size,
+        nothing_to_do=False,
+        update_data=True,
+        data_chunk=tapered_data,
+        update_flags=update_flags,
+        flags=combined_flags,
+    )
 
 
 class TukeyTractorOptions(BaseOptions):
@@ -821,7 +906,7 @@ def tukey_tractor(
                 number_of_chunks=tukey_tractor_options.max_workers,
             ):
                 start_tukey = time()
-                taper_data_and_flags: list[tuple[DataChunk, NDArray[np.bool_]]] = []
+                taper_data_and_flags: list[TaperedChunkResult] = []
                 if len(data_chunk_tuple) == 1:
                     taper_results = partial_compute_func(
                         data_chunk=data_chunk_tuple[0],
@@ -843,27 +928,46 @@ def tukey_tractor(
 
                 # Iterate over the result set in a serial manner. Note that depending on
                 # how the .map is called in max_workers>1 case this could be a generator
-                for taper_data_chunk, flags_to_apply in taper_data_and_flags:
-                    pbar.update(len(taper_data_chunk.masked_data))
+                # for taper_data_chunk, flags_to_apply in taper_data_and_flags:
+                taper_chunk_result: TaperedChunkResult
+                for taper_chunk_result in taper_data_and_flags:
+                    pbar.update(taper_chunk_result.chunk_size)
+
+                    if taper_chunk_result.nothing_to_do:
+                        logger.debug("No attached data payload, skipping")
+                        continue
+
+                    data_chunk = taper_chunk_result.data_chunk
+                    assert data_chunk is not None, (
+                        f"{data_chunk=}, which should not happen"
+                    )
 
                     # Only update here is we pass the dry run check above
-                    open_ms_tables.main_table.putcol(
-                        columnname=tukey_tractor_options.output_column,
-                        value=taper_data_chunk.masked_data,
-                        startrow=taper_data_chunk.row_start,
-                        nrow=taper_data_chunk.chunk_size,
-                    )
-                    if flags_to_apply is not None:
+                    if taper_chunk_result.update_data:
+                        open_ms_tables.main_table.putcol(
+                            columnname=tukey_tractor_options.output_column,
+                            value=data_chunk.masked_data,
+                            startrow=data_chunk.row_start,
+                            nrow=data_chunk.chunk_size,
+                        )
+                    else:
+                        logger.debug("No update of data required, skipping")
+                    if taper_chunk_result.update_flags:
                         open_ms_tables.main_table.putcol(
                             columnname="FLAG",
-                            value=flags_to_apply,
-                            startrow=taper_data_chunk.row_start,
-                            nrow=taper_data_chunk.chunk_size,
+                            value=taper_chunk_result.flags,
+                            startrow=data_chunk.row_start,
+                            nrow=data_chunk.chunk_size,
+                        )
+                    else:
+                        logger.debug(
+                            "No updating of flags required, skipping for chunk"
                         )
         stop = time()
         runtime_s = stop - start
+        assert data_chunk is not None, "data_chunk is not formed correctly"
         logger.info(
-            f"Tapered {len(tukey_tractor_options.target_objects)} targets over {len(open_ms_tables.main_table)} rows by {len(taper_data_chunk.freq_chan)} chans in {runtime_s:0.2f}s"
+            f"Tapered {len(tukey_tractor_options.target_objects)} targets over {len(open_ms_tables.main_table)} rows by {len(data_chunk.freq_chan)} chans in {runtime_s:0.2f}s"
         )
 
         logger.info(

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -740,7 +740,9 @@ def _tukey_multi_tractor(
 
     # Handle all the cases
     if all(not taper_result.attached_payload for taper_result in taper_results):
-        return TaperedChunkResult(chunk_size=chunk_size, nothing_to_do=True)
+        return TaperedChunkResult(
+            chunk_size=chunk_size, nothing_to_do=True, data_chunk=data_chunk
+        )
 
     # Throw away objects that are unnecessary in subsequent stages
     taper_results = [
@@ -933,7 +935,13 @@ def tukey_tractor(
                 for taper_chunk_result in taper_data_and_flags:
                     pbar.update(taper_chunk_result.chunk_size)
 
-                    if taper_chunk_result.nothing_to_do:
+                    # TODO: This needs to have a check in place to see if adata are being written out to the
+                    # input column as well. Essentially we have to write out if the column is new and we have
+                    # not copied it up front.
+                    if (
+                        taper_chunk_result.nothing_to_do
+                        and tukey_tractor_options.copy_column_data
+                    ):
                         logger.debug("No attached data payload, skipping")
                         continue
 
@@ -942,8 +950,12 @@ def tukey_tractor(
                         f"{data_chunk=}, which should not happen"
                     )
 
-                    # Only update here is we pass the dry run check above
-                    if taper_chunk_result.update_data:
+                    # Only update here is we pass the dry run check above. If data are not copied
+                    # upfront for new column than this is necessary
+                    if (
+                        taper_chunk_result.update_data
+                        or not tukey_tractor_options.copy_column_data
+                    ):
                         open_ms_tables.main_table.putcol(
                             columnname=tukey_tractor_options.output_column,
                             value=data_chunk.masked_data,

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -381,6 +381,7 @@ def make_plot_results(
     w_delays: WDelays | list[WDelays] | None = None,
     reverse_baselines: bool = False,
     outer_width_ns: float | None = None,
+    max_baselines: int = 10,
 ) -> list[Path]:
     """Create plots useful for diagnostics
 
@@ -392,10 +393,13 @@ def make_plot_results(
         w_delays (WDelays | None, optional): Description of a track through delay space. If ``None`` some plotting will be skipped. Defaults to None.
         reverse_baselines (bool, optional): Needed in some circumstances should antenna ordering in MS be different. Defaults to False.
         outer_width_ns (float | None, optional): Size, in nanoseconds, of the tukey taper. Defaults to None.
+        max_baselines (int, optional): The maximum number of baseline plots to create. Defaults to 10.
 
     Returns:
         list[Path]: Collection of paths to use
     """
+    assert max_baselines > 0, f"{max_baselines=}, but should be at least 0"
+
     output_paths = []
     output_dir = open_ms_tables.ms_path.parent / "plots"
     output_dir.mkdir(exist_ok=True, parents=True)
@@ -405,7 +409,6 @@ def make_plot_results(
 
     logger.info(f"MS contains {n_ant} antennas ({len(b_idx)} baselines)")
 
-    max_baselines = 10
     b_idx = b_idx[:max_baselines]
     logger.info(f"Plotting {len(b_idx)} baselines")
 
@@ -708,6 +711,8 @@ class TukeyTractorOptions(BaseOptions):
     """Indicates whether the data will be written back to the measurement set"""
     make_plots: bool = False
     """Create a small set of diagnostic plots. This can be slow."""
+    number_of_plots: int = 10
+    """The number of output plots to make. Defaults to 10."""
     overwrite: bool = False
     """If the output column exists it will be overwritten"""
     chunk_size: int = 1000
@@ -876,6 +881,7 @@ def tukey_tractor(
             w_delays=w_delays_list,
             reverse_baselines=tukey_tractor_options.reverse_baselines,
             outer_width_ns=tukey_tractor_options.outer_width_ns,
+            max_baselines=tukey_tractor_options.number_of_plots,
         )
 
         logger.info(f"Made {len(plot_paths)} output plots")

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -873,6 +873,7 @@ def _set_auto_taper_widths(
         outer_width_ns=outer_width_ns,
         tukey_width_ns=0.0,  # type: ignore[arg-type]
     )
+    # TODO: Removing the type ignore above results in a mypy error in capn_crunch
 
 
 def tukey_tractor(

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -911,6 +911,7 @@ def tukey_tractor(
             w_delays_list=w_delays_list,
         )
 
+        logger.info(f"Incremental data flushes {write_back_required=}")
         start = time()
         total_tukey_time_s = 0.0
         with tqdm(total=len(open_ms_tables.main_table), desc="Rows") as pbar:

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -411,7 +411,7 @@ def make_plot_results(
     Returns:
         list[Path]: Collection of paths to use
     """
-    assert max_baselines > 0, f"{max_baselines=}, but should be at least 0"
+    assert max_baselines > 0, f"{max_baselines=}, but should be at least 1"
 
     output_paths = []
     output_dir = open_ms_tables.ms_path.parent / "plots"

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -30,6 +30,7 @@ from jolly_roger.baselines import (
 from jolly_roger.delays import DelayTime, data_to_delay_time, delay_time_to_data
 from jolly_roger.logging import logger
 from jolly_roger.plots import plot_baseline_comparison_data
+from jolly_roger.response import calculate_expected_sinc_width
 from jolly_roger.utils import log_dataclass_attributes, log_jolly_roger_version
 from jolly_roger.uvws import WDelays, get_object_delay_for_ms
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
@@ -832,6 +833,8 @@ class TukeyTractorOptions(BaseOptions):
     """The number of compute processes to establish. Each process gets chunk_size of rows. If max_worker==1 all work is performed in main thread."""
     compare_to_field: float | None = None
     """Compare the source brightness in delay space to the field. If the source is fainter than the field multiplied by this factor, do not taper. Defaults to None."""
+    auto_size: bool = False
+    """Automatically size the outer width of the tukey taper based on the data"""
 
 
 @dataclass(frozen=True)
@@ -844,6 +847,32 @@ class TukeyTractorResults:
     """The name of the column that has the modified/tapered visibilities"""
     output_plots: list[Path] | None = None
     """The output plots that were created, if any"""
+
+
+def _set_auto_taper_widths(
+    open_ms_tables: OpenMSTables, tukey_tractor_options: TukeyTractorOptions
+) -> TukeyTractorOptions:
+    """Obtain the expected size of the sinc function for the spectral information
+    contained in the MS
+
+    Args:
+        open_ms_tables (OpenMSTables): Collection of MS tables to inspected
+        tukey_tractor_options (TukeyTractorOptions): Tukey tractor options to inspect
+
+    Returns:
+        TukeyTractorOptions: Duplicate options as input, expect the specification of the taper is overwritten
+    """
+
+    freq_chan = open_ms_tables.spw_table.getcol("CHAN_FREQ").squeeze() * u.Hz
+
+    sinc_width = calculate_expected_sinc_width(freqs=freq_chan)
+    outer_width_ns = sinc_width.to("ns").value
+    logger.info(f"Setting automatic {outer_width_ns=}")
+
+    return tukey_tractor_options.with_options(
+        outer_width_ns=outer_width_ns,
+        tukey_width_ns=0.0,  # type: ignore[arg-type]
+    )
 
 
 def tukey_tractor(
@@ -871,8 +900,13 @@ def tukey_tractor(
 
     # acquire all the tables necessary to get unit information and data from
     open_ms_tables = get_open_ms_tables(ms_path=ms_path, read_only=False)
-    write_back_required: bool = True
 
+    if tukey_tractor_options.auto_size:
+        tukey_tractor_options = _set_auto_taper_widths(
+            open_ms_tables=open_ms_tables, tukey_tractor_options=tukey_tractor_options
+        )
+
+    write_back_required: bool = True
     if not tukey_tractor_options.dry_run:
         # Data will need to be written back to the MS after each chunk if the
         # output column has not data

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -30,7 +30,10 @@ from jolly_roger.baselines import (
 from jolly_roger.delays import DelayTime, data_to_delay_time, delay_time_to_data
 from jolly_roger.logging import logger
 from jolly_roger.plots import plot_baseline_comparison_data
-from jolly_roger.response import calculate_expected_sinc_width
+from jolly_roger.response import (
+    calculate_expected_sinc_width,
+    get_delay_of_nth_sidelobe,
+)
 from jolly_roger.utils import log_dataclass_attributes, log_jolly_roger_version
 from jolly_roger.uvws import WDelays, get_object_delay_for_ms
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
@@ -529,6 +532,7 @@ def _tukey_tractor(
     tukey_tractor_options: TukeyTractorOptions,
     w_delays: WDelays,
     delay_time: DelayTime | None = None,
+    sidelobe_offset: u.Quantity | None = None,
 ) -> TaperResult:
     """Compute a tukey taper for a dataset and then apply it
     to the dataset. Here the data corresponds to a (chan, time, pol)
@@ -544,6 +548,7 @@ def _tukey_tractor(
         tukey_tractor_options (TukeyTractorOptions): Options for the tukey taper
         w_delays (WDelays): The w-derived delays to apply.
         delay_time (DelayTime | None, optional): Optional pre-computed DelayTime object.
+        sidelobe_offset (u.Quantity | None, optional): If provided, the tukey taper will be offset by this amount in delay space in order to target specific sidelobes of the response. Defaults to None.
 
     Returns:
         TaperResult: Scaled complex visibilities, corresponding flags, and delays.
@@ -573,6 +578,8 @@ def _tukey_tractor(
 
     # Make a copy for later use post wrapping
     tukey_x_offset = original_tukey_x_offset.copy()
+    if isinstance(sidelobe_offset, u.Quantity):
+        tukey_x_offset += sidelobe_offset.to(u.s)
 
     # need to scale the x offset to the -pi to pi (radians) wrap
     # keeping units in seconds though
@@ -735,6 +742,8 @@ def _tukey_multi_tractor(
 ) -> TaperedChunkResult:
     chunk_size = data_chunk.chunk_size
 
+    outer_width = tukey_tractor_options.outer_width_ns * 1e-9 * u.s
+
     # Get the results for each object. Note reusing the delay_time object
     # to avoid unnecessary recomputes. Also why the for loop and not list comphrension
     delay_time: DelayTime | None = None
@@ -748,6 +757,29 @@ def _tukey_multi_tractor(
         )
         delay_time = taper_result.delay_time
         taper_results.append(taper_result)
+
+        if (
+            not taper_result.attached_payload
+            or tukey_tractor_options.nth_sidelobe_null is None
+        ):
+            continue
+
+        # If sidelobe nulling is used than the outer_width has been configured
+        # by the auto-size option
+        for sign in (1, -1):
+            for sidelobe in range(1, tukey_tractor_options.nth_sidelobe_null + 1):
+                sidelobe_offset = get_delay_of_nth_sidelobe(
+                    n=sidelobe, sinc_width=outer_width
+                )
+                taper_result = _tukey_tractor(
+                    data_chunk=data_chunk,
+                    tukey_tractor_options=tukey_tractor_options,
+                    w_delays=w_delays,
+                    delay_time=delay_time,
+                    sidelobe_offset=sidelobe_offset * sign,
+                )
+                delay_time = taper_result.delay_time
+                taper_results.append(taper_result)
 
     # Handle all the cases
     if all(not taper_result.attached_payload for taper_result in taper_results):
@@ -835,6 +867,8 @@ class TukeyTractorOptions(BaseOptions):
     """Compare the source brightness in delay space to the field. If the source is fainter than the field multiplied by this factor, do not taper. Defaults to None."""
     auto_size: bool = False
     """Automatically size the outer width of the tukey taper based on the data"""
+    nth_sidelobe_null: int | None = None
+    """Null up to the N'th sidelobe. Only used in auto_size mode. Defaults to None."""
 
 
 @dataclass(frozen=True)
@@ -898,6 +932,17 @@ def tukey_tractor(
     log_dataclass_attributes(
         to_log=tukey_tractor_options, class_name="TukeyTaperOptions"
     )
+
+    if (
+        not tukey_tractor_options.auto_size
+        and tukey_tractor_options.nth_sidelobe_null is not None
+    ):
+        logger.warning(
+            "nth_sidelobe_null is only used in auto_size mode. Since auto_size is False, nth_sidelobe_null will be ignored."
+        )
+        tukey_tractor_options = tukey_tractor_options.with_options(
+            nth_sidelobe_null=None,  # type: ignore[arg-type]
+        )
 
     # acquire all the tables necessary to get unit information and data from
     open_ms_tables = get_open_ms_tables(ms_path=ms_path, read_only=False)

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -309,7 +309,7 @@ def add_output_column(
     output_column: str = "CORRECTED_DATA",
     overwrite: bool = False,
     copy_column_data: bool = False,
-) -> None:
+) -> bool:
     """Add in the output data column where the modified data
     will be recorded
 
@@ -320,9 +320,14 @@ def add_output_column(
         overwrite (bool, optional): Whether to overwrite the new output column. Defaults to False.
         copy_column_data (bool, optional): Copy the original data over to the output column. Defaults to False.
 
+    Retuurns:
+        bool: Indicates whether output column is empty (True) or contains data (False). This is useful for determining whether to write back to the MS after applying the taper.
+
     Raises:
         ValueError: Raised if the output column already exists and overwrite is False
+
     """
+    column_is_empty: bool = True
     colnames = tab.colnames()
     if output_column in colnames:
         if not overwrite:
@@ -332,16 +337,21 @@ def add_output_column(
         logger.warning(
             f"Output column {output_column} already exists in the measurement set. Will be overwritten!"
         )
+        column_is_empty = False
     else:
         logger.info(f"Adding {output_column=}")
         desc = makecoldesc(data_column, tab.getcoldesc(data_column))
         desc["name"] = output_column
         tab.addcols(desc)
         tab.flush()
+        column_is_empty = True
 
     if copy_column_data:
         logger.info(f"Copying {data_column=} to {output_column=}")
         taql(f"UPDATE $tab SET {output_column}={data_column}")
+        column_is_empty = False
+
+    return column_is_empty
 
 
 def write_output_column(
@@ -861,9 +871,12 @@ def tukey_tractor(
 
     # acquire all the tables necessary to get unit information and data from
     open_ms_tables = get_open_ms_tables(ms_path=ms_path, read_only=False)
+    write_back_required: bool = True
 
     if not tukey_tractor_options.dry_run:
-        add_output_column(
+        # Data will need to be written back to the MS after each chunk if the
+        # output column has not data
+        write_back_required = add_output_column(
             tab=open_ms_tables.main_table,
             output_column=tukey_tractor_options.output_column,
             data_column=tukey_tractor_options.data_column,
@@ -935,13 +948,7 @@ def tukey_tractor(
                 for taper_chunk_result in taper_data_and_flags:
                     pbar.update(taper_chunk_result.chunk_size)
 
-                    # TODO: This needs to have a check in place to see if adata are being written out to the
-                    # input column as well. Essentially we have to write out if the column is new and we have
-                    # not copied it up front.
-                    if (
-                        taper_chunk_result.nothing_to_do
-                        and tukey_tractor_options.copy_column_data
-                    ):
+                    if taper_chunk_result.nothing_to_do and not write_back_required:
                         logger.debug("No attached data payload, skipping")
                         continue
 
@@ -952,10 +959,7 @@ def tukey_tractor(
 
                     # Only update here is we pass the dry run check above. If data are not copied
                     # upfront for new column than this is necessary
-                    if (
-                        taper_chunk_result.update_data
-                        or not tukey_tractor_options.copy_column_data
-                    ):
+                    if taper_chunk_result.update_data or write_back_required:
                         open_ms_tables.main_table.putcol(
                             columnname=tukey_tractor_options.output_column,
                             value=data_chunk.masked_data,

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,109 @@
+"""Tests for the sinc response utilieis"""
+
+from __future__ import annotations
+
+import astropy.units as u
+import numpy as np
+
+from jolly_roger.response import (
+    calculate_expected_sinc_width,
+    get_delay_of_nth_sidelobe,
+)
+
+# Example code used to investigate and create tests
+"""
+import numpy as np
+import astropy.units as u
+import matplotlib.pyplot as plt
+
+no_chans = 288
+freqs = (np.arange(no_chans) + 800) * u.MHz
+bandpass = np.ones(no_chans)
+
+
+diff = (1 / (freqs.max() - freqs.min())).decompose().to("s").value
+
+fft_band = np.fft.fftshift(
+    np.fft.fft(bandpass, norm="backward")
+)
+fft_delay = np.fft.fftshift(
+    np.fft.fftfreq(no_chans, np.diff(freqs)[0])
+)
+
+offt_band = np.fft.fftshift(
+    np.fft.fft(bandpass, 10028, norm="backward"),
+)
+offt_delay = np.fft.fftshift(
+    np.fft.fftfreq(10028, np.diff(freqs)[0])
+)
+
+
+fig, ax = plt.subplots(1,1)
+
+
+ax.plot(
+    offt_delay.to("s").value,
+    np.abs(offt_band),
+    label="Top hat"
+)
+
+ax.plot(
+    fft_delay.to("s").value,
+    np.abs(fft_band),
+    label="Padded Tophat"
+)
+
+ax.axvline(-diff, color="black", label="Main lobe")
+ax.axvline(diff, color="black")
+
+ax.set(
+    xlim=[-0.5e-7, 0.5e-7],
+    xlabel="Delay / s",
+    ylabel="Power"
+)
+
+for i in range(1, 10):
+    space = diff * (i + 0.5)
+    ax.axvline(space, label="Sidelobe" if i==1 else None)
+    ax.axvline(-space)
+
+
+ax.legend()
+"""
+
+
+def test_calculate_sinc_width() -> None:
+    """Calculate the expected sinc response width in delay space from
+    a set of known frequencies"""
+
+    no_chans = 288
+    freqs = (np.arange(no_chans) + 800) * u.MHz
+
+    width = calculate_expected_sinc_width(freqs=freqs)
+
+    assert width == (3.4843205574912892e-09 * u.s)
+
+
+def test_calculate_sinc_width_no_unit() -> None:
+    """Calculate the expected sinc response width in delay space from
+    a set of known frequencies. Same input as above but do not attach
+    frequency information to input"""
+
+    no_chans = 288
+    freqs_mhz = np.arange(no_chans) + 800
+
+    width = calculate_expected_sinc_width(freqs=freqs_mhz)
+
+    assert width == (3.4843205574912892e-09 * u.s)
+
+
+def test_nth_sidelobe() -> None:
+    """Ensure that an appropriate sidelobe position can be obtained"""
+
+    width = 3.4843205574912892e-09 * u.s
+    nth_sidelobe_delay = get_delay_of_nth_sidelobe(sinc_width=width, n=1)
+
+    assert nth_sidelobe_delay == (5.226480836236934e-09 * u.s)
+
+    nth_sidelobe_delay = get_delay_of_nth_sidelobe(sinc_width=width, n=4)
+    assert nth_sidelobe_delay == (1.5679442508710802e-08 * u.s)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -107,3 +107,6 @@ def test_nth_sidelobe() -> None:
 
     nth_sidelobe_delay = get_delay_of_nth_sidelobe(sinc_width=width, n=4)
     assert nth_sidelobe_delay == (1.5679442508710802e-08 * u.s)
+
+    nth_sidelobe_delay = get_delay_of_nth_sidelobe(sinc_width=width, n=0)
+    assert nth_sidelobe_delay == (0 * u.s)


### PR DESCRIPTION
This is becoming a larger change than what was initially sketched. There are three main components:
- an additional check to avoid unnecessarily nulling towards an object
- checks to avoid unnecessary write-backs to the MS
- an attempt to automatically construct the appropriate null width and to null sidelobes.

On point 1, we do this by constructing the tapers towards the field direction (delay=0) and the object, multiplying by (1-taper), and then comparing the maximum signal in both arrays. Should a user provided relative fraction be met (i.e. there is sufficient signal in the object direction relative to the delay direction) then the null is applied. 

On point 2, in earlier version of the jolly tractor we are always writing back the data chunk and thee flags corresponding to the data. This is done even if the data-column was copied upfront to the output column, and the data / flags remain unchanged. I have tried to introduce some better logic to identify instances where some of these write backs can be avoided. The implementation of this is basically expanding the returns of the internal tukey functions to return more state with additional flags that can be checked in the main chunking iterator. A check also has been added to force write back in the case that the data column is not copied in complete form to the output column up front. 

On point 3, it is rough outline of what could be done. Each sidelobe is compared to the main field direction. I think that there might have to be some additional work to make this properly robust, but the bits and pieces are at least mocked up, and the behavious is opt-in vla explicit CLI. 