### PR TITLE
added checks for single FIELD_ID

### DIFF
--- a/jolly_roger/baselines.py
+++ b/jolly_roger/baselines.py
@@ -32,6 +32,36 @@ class OpenMSTables:
     """The field table"""
     ms_path: Path
     """The path to the MS used to open tables"""
+    phase_dir: SkyCoord
+    """The phase direction appropriate for the data"""
+
+
+def _get_phase_dir_for_field_id(ms_table: table, field_table: table) -> SkyCoord:
+    """Examine the FIELD_IDs in the main ms data table to extract the
+    appropriate phase direction from the MS field table. Useful should
+    there be multiple fields recorded in the meta-data table. A strong
+    constrain of a single FIELD_ID is enforced in the main data table.
+
+    Args:
+        ms_table (table): The opened main data table in an MS
+        field_table (table): The corresponding opened FIELD table
+
+    Raises:
+        ValueError: Raised when more than one FIELD_ID is found in the data table
+
+    Returns:
+        SkyCoord: The phase direction of the field
+    """
+
+    field_id = np.unique(ms_table.getcol("FIELD_ID"))
+    if len(field_id) > 1:
+        msg = f"Expected a single FIELD_ID, found: {field_id=}"
+        raise ValueError(msg)
+
+    field_id = field_id[0]
+
+    sky_pos = field_table.getcol("PHASE_DIR")[field_id]
+    return SkyCoord(*(sky_pos).squeeze() * u.rad)
 
 
 def get_open_ms_tables(ms_path: Path, read_only: bool = True) -> OpenMSTables:
@@ -48,6 +78,9 @@ def get_open_ms_tables(ms_path: Path, read_only: bool = True) -> OpenMSTables:
     spw_table = table(str(ms_path / "SPECTRAL_WINDOW"), ack=False, readonly=read_only)
     field_table = table(str(ms_path / "FIELD"), ack=False, readonly=read_only)
 
+    phase_dir = _get_phase_dir_for_field_id(
+        ms_table=main_table, field_table=field_table
+    )
     # TODO: Get the data without auto-correlations e.g.
     # no_auto_main_table = taql(
     #     "select from $main_table where ANTENNA1 != ANTENNA2",
@@ -58,6 +91,7 @@ def get_open_ms_tables(ms_path: Path, read_only: bool = True) -> OpenMSTables:
         spw_table=spw_table,
         field_table=field_table,
         ms_path=ms_path,
+        phase_dir=phase_dir,
     )
 
 
@@ -135,7 +169,6 @@ def get_baseline_data(
     logger.info(f"Getting baseline {ant_1} {ant_2}")
 
     freq_chan = open_ms_tables.spw_table.getcol("CHAN_FREQ")
-    phase_dir = open_ms_tables.field_table.getcol("PHASE_DIR")
 
     logger.debug(f"Processing {ant_1=} {ant_2=}")
 
@@ -147,7 +180,7 @@ def get_baseline_data(
     )
 
     freq_chan = freq_chan.squeeze() * u.Hz
-    target = SkyCoord(*(phase_dir * u.rad).squeeze())
+    phase_dir = open_ms_tables.phase_dir
     uvws_phase_center = np.swapaxes(baseline_data.uvws * u.m, 0, 1)
     time = Time(
         baseline_data.time_centroid.squeeze() * u.s,
@@ -161,7 +194,7 @@ def get_baseline_data(
         ms_path=open_ms_tables.ms_path,
         masked_data=masked_data,
         freq_chan=freq_chan,
-        phase_center=target,
+        phase_center=phase_dir,
         uvws_phase_center=cast(u.Quantity, uvws_phase_center),
         time=time,
         ant_1=ant_1,

--- a/jolly_roger/hour_angles.py
+++ b/jolly_roger/hour_angles.py
@@ -76,13 +76,25 @@ def _process_position(
             position = SkyCoord.from_name(position)
 
     if position is None:
+        # Best effort basis here
         if ms_path is None:
             msg = f"{position=}, so default position can't be drawn. Provide a ms_path="
             raise ValueError(msg)
 
-        with table(str(ms_path / "FIELD")) as tab:
+        logger.info("Examining FIELD_ID in data table")
+        with table(str(ms_path), readonly=True, ack=False) as tab:
+            field_id = np.unique(tab.getcol("FIELD_ID"))
+            logger.info(f"Found {len(field_id)} field directions")
+            if field_id > 1:
+                msg = f"More than one field found in data table, {field_id=}"
+                raise ValueError(msg)
+
+            field_id = field_id[0]
+
+        with table(str(ms_path / "FIELD"), readonly=True, ack=False) as tab:
             logger.info(f"Getting the sky-position from PHASE_DIR of {ms_path=}")
-            field_positions = tab.getcol("PHASE_DIR")[:]
+            field_positions = tab.getcol("PHASE_DIR")[field_id]
+            logger.info(f"Extracted {field_positions=}")
             position = SkyCoord(*(field_positions * u.rad).squeeze())
 
     if isinstance(position, SkyCoord):
@@ -128,6 +140,7 @@ def make_hour_angles_for_ms(
 
     Args:
         ms_path (Path): Measurement set to usefor time and sky-position information
+        phase_dir (SkyCoord): The phase direction of the measurement set
         position (SkyCoord | str | None, optional): The sky-direction hour-angles will be calculated towards. Defaults to None.
         whole_day (bool, optional): Calaculate for a 24 hour persion starting from the first time step. Defaults to False.
 

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -223,10 +223,9 @@ def get_data_chunks(
         Generator[DataChunk, None, None]: Representation of the current chunk of rows
     """
     freq_chan = open_ms_tables.spw_table.getcol("CHAN_FREQ")
-    phase_dir = open_ms_tables.field_table.getcol("PHASE_DIR")
+    phase_dir = open_ms_tables.phase_dir
 
     freq_chan = freq_chan.squeeze() * u.Hz
-    target = SkyCoord(*(phase_dir * u.rad).squeeze())
 
     for data_chunk_array in _get_data_chunk_from_main_table(
         ms_table=open_ms_tables.main_table,
@@ -247,7 +246,7 @@ def get_data_chunks(
         yield DataChunk(
             masked_data=masked_data,
             freq_chan=freq_chan,
-            phase_center=target,
+            phase_center=phase_dir,
             uvws_phase_center=uvws_phase_center,
             time=time,
             time_mjds=data_chunk_array.time_centroid,
@@ -752,6 +751,7 @@ def tukey_tractor(
     # Generate the delay for all baselines and time steps
     w_delays_list = get_object_delay_for_ms(
         ms_path=ms_path,
+        phase_dir=open_ms_tables.phase_dir,
         object_name=tukey_tractor_options.target_objects,
         reverse_baselines=tukey_tractor_options.reverse_baselines,
         flip_uvw_sign=tukey_tractor_options.flip_uvw_sign,

--- a/jolly_roger/uvws.py
+++ b/jolly_roger/uvws.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import astropy.units as u
 import numpy as np
 from astropy.constants import c as speed_of_light
+from astropy.coordinates import SkyCoord
 from casacore.tables import table, taql
 from tqdm import tqdm
 
@@ -38,6 +39,7 @@ class WDelays:
 
 def get_object_delay_for_ms(
     ms_path: Path,
+    phase_dir: SkyCoord,
     object_name: str | list[str] | tuple[str, ...] = "sun",
     reverse_baselines: bool = False,
     flip_uvw_sign: bool = False,
@@ -54,7 +56,7 @@ def get_object_delay_for_ms(
     )
     hour_angles_phase = make_hour_angles_for_ms(
         ms_path=ms_path,
-        position=None,  # gets the position from phase direction
+        position=phase_dir,  # gets the position from phase direction
     )
     uvws_phase = xyz_to_uvw(
         baselines=baselines, hour_angles=hour_angles_phase, flip_uvw_sign=flip_uvw_sign
@@ -65,7 +67,7 @@ def get_object_delay_for_ms(
     for _object_name in object_name:
         hour_angles_object = make_hour_angles_for_ms(
             ms_path=ms_path,
-            position=_object_name,  # gets the position from phase direction
+            position=_object_name,  # gets the position from phase direction,
         )
         uvws_object = xyz_to_uvw(
             baselines=baselines,


### PR DESCRIPTION
It was pointed out by @mattwhiting that jolly-roger was failing for some GASKAP OH data. I had a bit of a dig around and it appears as though we were getting bitten by multiple fields being described in the FIELD table, even if only one was referenced by the FIELD_ID in the main data table. 

In this PR I have introduced a `phase_dir` to the `OpenMSTables` class. It checks up front which field id is being used, and gets the appropriate row from the FIELD table. An appropriate check is also placed to ensure that only a sngle FIELD_ID is being used. 

This PR does not attempt to handle multiple different fields being referenced in a single data table - it just resolves which row in the FIELD table is being used. 