### PR TITLE
Test mask state when considering plotting normalisation

### DIFF
--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -93,15 +93,13 @@ def plot_baseline_comparison_data(
             if not after_amp_stokesi.mask.all()
             else before_amp_stokesi
         )
-        if not norm_plot_data.all():
-            try:
-                norm = ImageNormalize(
-                    norm_plot_data,
-                    interval=ZScaleInterval(),
-                    stretch=SqrtStretch(),
-                )
-            except (ValueError, IndexError):
-                logger.warning("Automatic normalisation failed. Continuing.")
+        if not norm_plot_data.mask.all():
+            norm = ImageNormalize(
+                norm_plot_data,
+                interval=ZScaleInterval(),
+                stretch=SqrtStretch(),
+            )
+        
         else:
             logger.warning("No valid data found. No attempt to normalise data.")
 

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -100,7 +100,7 @@ def plot_baseline_comparison_data(
                     interval=ZScaleInterval(),
                     stretch=SqrtStretch(),
                 )
-            except ValueError:
+            except (ValueError, IndexError):
                 logger.warning("Automatic normalisation failed. Continuing.")
         else:
             logger.warning("No valid data found. No attempt to normalise data.")

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -99,7 +99,7 @@ def plot_baseline_comparison_data(
                 interval=ZScaleInterval(),
                 stretch=SqrtStretch(),
             )
-        
+
         else:
             logger.warning("No valid data found. No attempt to normalise data.")
 

--- a/jolly_roger/plots.py
+++ b/jolly_roger/plots.py
@@ -87,20 +87,23 @@ def plot_baseline_comparison_data(
         # We may end up flagging all the data. If the after data is completely flagged, fall back
         # to the before data. If, however, all that is also flagged (e.g. sun is too close across
         # all timesteps and hence all timesteps are flagged) we no normalise.
+        norm = None
         norm_plot_data = (
             after_amp_stokesi
             if not after_amp_stokesi.mask.all()
             else before_amp_stokesi
         )
         if not norm_plot_data.all():
-            norm = ImageNormalize(
-                norm_plot_data,
-                interval=ZScaleInterval(),
-                stretch=SqrtStretch(),
-            )
+            try:
+                norm = ImageNormalize(
+                    norm_plot_data,
+                    interval=ZScaleInterval(),
+                    stretch=SqrtStretch(),
+                )
+            except ValueError:
+                logger.warning("Automatic normalisation failed. Continuing.")
         else:
             logger.warning("No valid data found. No attempt to normalise data.")
-            norm = None
 
         cmap = plt.cm.viridis
 


### PR DESCRIPTION
There was a slight oversight when an earlier change was testing the appropriateness of a matplotlib Normalization object. We ought to be testing the mask state of the data.  