### PR TITLE
Scale the weights based on the taper

### DIFF
--- a/jolly_roger/baselines.py
+++ b/jolly_roger/baselines.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -121,8 +121,8 @@ class BaselineData:
 class BaselineArrays:
     data: NDArray[np.complexfloating]
     flags: NDArray[np.bool_]
-    uvws: NDArray[np.floating]
-    time_centroid: NDArray[np.floating]
+    uvws: NDArray[np.floating[Any]]
+    time_centroid: NDArray[np.floating[Any]]
 
 
 def _get_baseline_data(

--- a/jolly_roger/response.py
+++ b/jolly_roger/response.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import astropy.units as u
 import numpy as np
 from numpy.typing import NDArray
@@ -22,7 +24,7 @@ N'th sidelobe.
 
 
 def calculate_expected_sinc_width(
-    freqs: NDArray[np.floating] | u.Quantity,
+    freqs: NDArray[np.floating[Any]] | u.Quantity,
 ) -> u.Quantity:
     """The expected width of a sinc response in delay space given a set of frequencies,
 
@@ -31,7 +33,7 @@ def calculate_expected_sinc_width(
     bandwidth of the frequencies.
 
     Args:
-        freqs (NDArray[np.floating] | u.Quantity): The sampled frequencies. If units are not specified MHz are assumed.
+        freqs (NDArray[np.floating[Any]] | u.Quantity): The sampled frequencies. If units are not specified MHz are assumed.
 
     Returns:
         u.Quantity: The expected width of the sinc response
@@ -50,7 +52,7 @@ def calculate_expected_sinc_width(
 
 
 def get_delay_of_nth_sidelobe(
-    n: int, sinc_width: u.Quantity | np.floating
+    n: int, sinc_width: u.Quantity | np.floating[Any]
 ) -> u.Quantity:
     """Calculate the expected delay of the N'th sidelobe of a sinc response given the width of the sinc response.
 
@@ -62,7 +64,7 @@ def get_delay_of_nth_sidelobe(
 
     Args:
         n (int): The order of the sidelobe (1 for first sidelobe, 2 for second, etc.)
-        sinc_width (u.Quantity | np.floating): The width of the sinc response in seconds. If no units are attached seconds are assumed.
+        sinc_width (u.Quantity | np.floating[Any]): The width of the sinc response in seconds. If no units are attached seconds are assumed.
 
     Returns:
         u.Quantity: The expected delay of the N'th sidelobe in seconds.

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -868,7 +868,8 @@ class TukeyTractorOptions(BaseOptions):
     """Automatically size the outer width of the tukey taper based on the data"""
     nth_sidelobe_null: int | None = None
     """Null up to the N'th sidelobe. Only used in auto_size mode. Defaults to None."""
-
+    reweight: bool = False
+    """Attempt to identify a WEIGHT-like column and rescale to indicate modified data. Defaults to False."""
 
 @dataclass(frozen=True)
 class TukeyTractorResults:

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -36,7 +36,7 @@ from jolly_roger.response import (
 )
 from jolly_roger.utils import log_dataclass_attributes, log_jolly_roger_version
 from jolly_roger.uvws import WDelays, get_object_delay_for_ms
-from jolly_roger.weights import set_weight_column
+from jolly_roger.weights import select_weight_column
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
 
@@ -983,7 +983,7 @@ def tukey_tractor(
             open_ms_tables=open_ms_tables, tukey_tractor_options=tukey_tractor_options
         )
 
-    weights_column = set_weight_column(
+    weights_column = select_weight_column(
         ms_path=ms_path, weight_column=tukey_tractor_options.weight_column
     )
 

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -36,7 +36,7 @@ from jolly_roger.response import (
 )
 from jolly_roger.utils import log_dataclass_attributes, log_jolly_roger_version
 from jolly_roger.uvws import WDelays, get_object_delay_for_ms
-from jolly_roger.weights import select_weight_column
+from jolly_roger.weights import scale_weights, select_weight_column
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
 
@@ -760,6 +760,10 @@ class TaperedChunkResult:
     """"Indicates whether the flags need to be written back to MS"""
     flags: NDArray[bool] | None = None
     """The flags to write back"""
+    update_weights: bool = False
+    """Indicates whether data should be written back to the MS"""
+    weights: NDArray[np.floating] | None = None
+    """The scaled weights that should be written back to the MS. If None nothing to write back."""
 
 
 def _tukey_multi_tractor(
@@ -808,7 +812,8 @@ def _tukey_multi_tractor(
                 delay_time = taper_result.delay_time
                 taper_results.append(taper_result)
 
-    # Handle all the cases
+    # Handle all the cases. If all data chunks showed nothing to do we can
+    # return early and provide the original data back to the caller.
     if all(not taper_result.attached_payload for taper_result in taper_results):
         return TaperedChunkResult(
             chunk_size=chunk_size, nothing_to_do=True, data_chunk=data_chunk
@@ -845,6 +850,19 @@ def _tukey_multi_tractor(
         taper=combined_taper,
     )
 
+    # Should weights be provided to the DataChunk than it is assumed that they
+    # need to be scaleded based on the final taper. The driving functions that
+    # call into this multi tractor are responsible to writing this back out to
+    # the appropriate coluumn
+    scaled_weights: None | NDArray[np.floating] = None
+    update_weights = False
+    if data_chunk.weights is not None:
+        scaled_weights = scale_weights(taper=combined_taper, weights=data_chunk.weights)
+
+        # Should there actually be weights attached than at this point
+        # in the code path there is a taper that has been applied.
+        update_weights = True
+
     return TaperedChunkResult(
         chunk_size=chunk_size,
         nothing_to_do=False,
@@ -852,6 +870,8 @@ def _tukey_multi_tractor(
         data_chunk=tapered_data,
         update_flags=update_flags,
         flags=combined_flags,
+        update_weights=update_weights,
+        weights=scaled_weights,
     )
 
 
@@ -1097,6 +1117,15 @@ def tukey_tractor(
                         logger.debug(
                             "No updating of flags required, skipping for chunk"
                         )
+                    if taper_chunk_result.update_weights:
+                        open_ms_tables.main_table.putcol(
+                            columnname=weights_column,
+                            value=taper_chunk_result.weights,
+                            startrow=data_chunk.row_start,
+                            nrow=data_chunk.chunk_size,
+                        )
+                    else:
+                        logger.debug("No updating of weights")
         stop = time()
         runtime_s = stop - start
         assert data_chunk is not None, "data_chunk is not formed correctly"

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -207,6 +207,7 @@ def _get_data_chunk_from_main_table(
 
         weights = None
         if weights_column:
+            logger.info(f"Getting {weights_column=} {lower_row} {chunk_size}")
             weights = ms_table.getcol(
                 weights_column, startrow=lower_row, nrow=chunk_size
             )

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
@@ -36,7 +36,7 @@ from jolly_roger.response import (
 )
 from jolly_roger.utils import log_dataclass_attributes, log_jolly_roger_version
 from jolly_roger.uvws import WDelays, get_object_delay_for_ms
-from jolly_roger.weights import scale_weights, select_weight_column
+from jolly_roger.weights import scale_multiple_weights, select_weight_columns
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
 
@@ -130,8 +130,8 @@ class DataChunkArray:
     """The starting row of the portion of data loaded"""
     chunk_size: int
     """The size of the data chunk loaded (may be larger if this is the last record)"""
-    weights: NDArray[np.floating] | None = None
-    """The weights associated with the data. Only used if reweighting is activated. Defaults to None."""
+    weights: dict[str, NDArray[np.floating]] | None = None
+    """The weights associated with the data. Key is the column name and the mapped value are the corresponding weights. Only used if reweighting is activated. Defaults to None."""
 
 
 @dataclass
@@ -160,15 +160,15 @@ class DataChunk:
     """Starting row index of the data"""
     chunk_size: int
     """Size of the chunked portion of the data"""
-    weights: NDArray[np.floating] | None = None
-    """The weights associated with the data. Only used if reweighting is activated. Defaults to None."""
+    weights: dict[str, NDArray[np.floating]] | None = None
+    """The weights associated with the data. Key is the column name and the mapped value are the corresponding weights. Only used if reweighting is activated. Defaults to None."""
 
 
 def _get_data_chunk_from_main_table(
     ms_table: table,
     chunk_size: int,
     data_column: str,
-    weights_column: str | None = None,
+    weight_columns: Sequence[str] | None = None,
 ) -> Generator[DataChunkArray, None, None]:
     """Return an appropriately size data chunk from the main
     table of a measurement set. These data are ase they are
@@ -184,7 +184,7 @@ def _get_data_chunk_from_main_table(
         ms_table (table): The opened main table of a measurement set
         chunk_size (int): The size of the data to chunk and return
         data_column (str): The data column to be returned
-        weight_column (str | None, optional): The weight column to be returned. Defaults to None.
+        weight_columns (Sequence[str] | None, optional): The weight columns to be returned. Defaults to None.
 
     Yields:
         Generator[DataChunkArray, None, None]: A segment of rows and columns
@@ -206,10 +206,15 @@ def _get_data_chunk_from_main_table(
         ant_2 = ms_table.getcol("ANTENNA2", startrow=lower_row, nrow=chunk_size)
 
         weights = None
-        if weights_column:
-            logger.debug(f"Getting {weights_column=} {lower_row} {chunk_size}")
-            weights = ms_table.getcol(
-                weights_column, startrow=lower_row, nrow=chunk_size
+        if weight_columns:
+            weights = {
+                weight_column: ms_table.getcol(
+                    weight_column, startrow=lower_row, nrow=chunk_size
+                )
+                for weight_column in weight_columns
+            }
+            logger.debug(
+                f"Getting weights for {weight_columns=} {lower_row} {chunk_size}"
             )
 
         yield DataChunkArray(
@@ -231,7 +236,7 @@ def get_data_chunks(
     open_ms_tables: OpenMSTables,
     chunk_size: int,
     data_column: str,
-    weights_column: str | None = None,
+    weight_columns: Sequence[str] | None = None,
 ) -> Generator[DataChunk, None, None]:
     """Yield a collection of rows with appropriate units
     attached to the quantities. These quantities are not
@@ -243,7 +248,7 @@ def get_data_chunks(
         open_ms_tables (OpenMSTables): References to open tables from the measurement set
         chunk_size (int): The number of rows to return at a time
         data_column (str): The data column that would be modified
-        weights_column (str | None, optional): The weights column that would be modified if specified. Defaults to None.
+        weight_columns (Sequence[str] | None, optional): The weight columns that would be modified if specified. Defaults to None.
 
     Yields:
         Generator[DataChunk, None, None]: Representation of the current chunk of rows
@@ -257,7 +262,7 @@ def get_data_chunks(
         ms_table=open_ms_tables.main_table,
         chunk_size=chunk_size,
         data_column=data_column,
-        weights_column=weights_column,
+        weight_columns=weight_columns,
     ):
         # Transform the native arrays but attach astropy quantities
         uvws_phase_center = data_chunk_array.uvws * u.m
@@ -290,7 +295,7 @@ def get_multiple_data_chunks(
     chunk_size: int,
     data_column: str,
     number_of_chunks: int = 1,
-    weights_column: str | None = None,
+    weight_columns: Sequence[str] | None = None,
 ) -> Generator[tuple[DataChunk, ...], None, None]:
     """
     Wrapper around ``get_data_chunks`` to yield a list of
@@ -307,7 +312,7 @@ def get_multiple_data_chunks(
         chunk_size (int): The number of rows to return at a time
         data_column (str): The data column that would be modified
         number_of_chunks (int, optional): The number of chunks to return on each yield. Defaults to 1.
-        weights_column (str | None, optional): The weights column that would be modified if specified. Defaults to None.
+        weight_columns (Sequence[str] | None, optional): The weight columns that would be modified if specified. Defaults to None.
 
     Yields:
         Generator[tuple[DataChunk, ...], None, None]: Representation of the current chunk of rows
@@ -321,7 +326,7 @@ def get_multiple_data_chunks(
         open_ms_tables=open_ms_tables,
         chunk_size=chunk_size,
         data_column=data_column,
-        weights_column=weights_column,
+        weight_columns=weight_columns,
     ):
         base_chunks.append(data_chunk)
 
@@ -763,8 +768,8 @@ class TaperedChunkResult:
     """The flags to write back"""
     update_weights: bool = False
     """Indicates whether data should be written back to the MS"""
-    weights: NDArray[np.floating] | None = None
-    """The scaled weights that should be written back to the MS. If None nothing to write back."""
+    weights: dict[str, NDArray[np.floating]] | None = None
+    """The scaled weights that should be written back to the MS. The key is the column name and the mapped values are the corresponding scaled weights. If None nothing to write back."""
 
 
 def _tukey_multi_tractor(
@@ -855,10 +860,12 @@ def _tukey_multi_tractor(
     # need to be scaleded based on the final taper. The driving functions that
     # call into this multi tractor are responsible to writing this back out to
     # the appropriate coluumn
-    scaled_weights: None | NDArray[np.floating] = None
+    scaled_weights: None | dict[str, NDArray[np.floating]] = None
     update_weights = False
     if data_chunk.weights is not None:
-        scaled_weights = scale_weights(taper=combined_taper, weights=data_chunk.weights)
+        scaled_weights = scale_multiple_weights(
+            taper=combined_taper, weights=data_chunk.weights
+        )
 
         # Should there actually be weights attached than at this point
         # in the code path there is a taper that has been applied.
@@ -1004,7 +1011,7 @@ def tukey_tractor(
             open_ms_tables=open_ms_tables, tukey_tractor_options=tukey_tractor_options
         )
 
-    weights_column = select_weight_column(
+    weight_columns: Sequence[str] | None = select_weight_columns(
         ms_path=ms_path, weight_column=tukey_tractor_options.weight_column
     )
 
@@ -1057,7 +1064,7 @@ def tukey_tractor(
                 chunk_size=tukey_tractor_options.chunk_size,
                 data_column=tukey_tractor_options.data_column,
                 number_of_chunks=tukey_tractor_options.max_workers,
-                weights_column=weights_column,
+                weight_columns=weight_columns,
             ):
                 start_tukey = time()
                 taper_data_and_flags: list[TaperedChunkResult] = []
@@ -1120,12 +1127,19 @@ def tukey_tractor(
                         )
                     if taper_chunk_result.update_weights:
                         logger.debug("Updating weights")
-                        open_ms_tables.main_table.putcol(
-                            columnname=weights_column,
-                            value=taper_chunk_result.weights,
-                            startrow=data_chunk.row_start,
-                            nrow=data_chunk.chunk_size,
+                        assert taper_chunk_result.weights is not None, (
+                            "Expected weights to be attached, found None"
                         )
+                        for (
+                            weight_column_name,
+                            scaled_weights,
+                        ) in taper_chunk_result.weights.items():
+                            open_ms_tables.main_table.putcol(
+                                columnname=weight_column_name,
+                                value=scaled_weights,
+                                startrow=data_chunk.row_start,
+                                nrow=data_chunk.chunk_size,
+                            )
                     else:
                         logger.debug("No updating of weights")
         stop = time()

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -129,6 +129,8 @@ class DataChunkArray:
     """The starting row of the portion of data loaded"""
     chunk_size: int
     """The size of the data chunk loaded (may be larger if this is the last record)"""
+    weights: NDArray[np.floating] | None = None
+    """The weights associated with the data. Only used if reweighting is activated. Defaults to None."""
 
 
 @dataclass
@@ -157,22 +159,31 @@ class DataChunk:
     """Starting row index of the data"""
     chunk_size: int
     """Size of the chunked portion of the data"""
+    weights: NDArray[np.floating] | None = None
+    """The weights associated with the data. Only used if reweighting is activated. Defaults to None."""
 
 
 def _get_data_chunk_from_main_table(
     ms_table: table,
     chunk_size: int,
     data_column: str,
+    weight_column: str | None = None,
 ) -> Generator[DataChunkArray, None, None]:
     """Return an appropriately size data chunk from the main
     table of a measurement set. These data are ase they are
     in the measurement set without any additional scaling
     or unit adjustments.
 
+    Weights are only returned if the ``weight_column`` is
+    set. No distinction is made between a WEIGHT float or
+    a WEIGHT spectrum type data. No attempt to validate
+    existence of ``weight_column`` is made.
+
     Args:
         ms_table (table): The opened main table of a measurement set
         chunk_size (int): The size of the data to chunk and return
         data_column (str): The data column to be returned
+        weight_column (str | None, optional): The weight column to be returned. Defaults to None.
 
     Yields:
         Generator[DataChunkArray, None, None]: A segment of rows and columns
@@ -193,6 +204,12 @@ def _get_data_chunk_from_main_table(
         ant_1 = ms_table.getcol("ANTENNA1", startrow=lower_row, nrow=chunk_size)
         ant_2 = ms_table.getcol("ANTENNA2", startrow=lower_row, nrow=chunk_size)
 
+        weights = None
+        if weight_column:
+            weights = ms_table.getcol(
+                weight_column, startrow=lower_row, nrow=chunk_size
+            )
+
         yield DataChunkArray(
             data=data,
             flags=flags,
@@ -202,6 +219,7 @@ def _get_data_chunk_from_main_table(
             ant_2=ant_2,
             row_start=lower_row,
             chunk_size=chunk_size,
+            weights=weights,
         )
 
         lower_row += chunk_size

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -207,7 +207,7 @@ def _get_data_chunk_from_main_table(
 
         weights = None
         if weights_column:
-            logger.info(f"Getting {weights_column=} {lower_row} {chunk_size}")
+            logger.debug(f"Getting {weights_column=} {lower_row} {chunk_size}")
             weights = ms_table.getcol(
                 weights_column, startrow=lower_row, nrow=chunk_size
             )
@@ -1119,7 +1119,7 @@ def tukey_tractor(
                             "No updating of flags required, skipping for chunk"
                         )
                     if taper_chunk_result.update_weights:
-                        logger.info("Updating weights")
+                        logger.debug("Updating weights")
                         open_ms_tables.main_table.putcol(
                             columnname=weights_column,
                             value=taper_chunk_result.weights,

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -870,6 +870,9 @@ class TukeyTractorOptions(BaseOptions):
     """Null up to the N'th sidelobe. Only used in auto_size mode. Defaults to None."""
     reweight: bool = False
     """Attempt to identify a WEIGHT-like column and rescale to indicate modified data. Defaults to False."""
+    weight_column: str | None = None
+    """The name of the WEIGHT-like column. If None when rewrite is True the WEIGHT-like column will be searched for. Defaults to None."""
+
 
 @dataclass(frozen=True)
 class TukeyTractorResults:

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -36,6 +36,7 @@ from jolly_roger.response import (
 )
 from jolly_roger.utils import log_dataclass_attributes, log_jolly_roger_version
 from jolly_roger.uvws import WDelays, get_object_delay_for_ms
+from jolly_roger.weights import set_weight_column
 from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
 
@@ -167,7 +168,7 @@ def _get_data_chunk_from_main_table(
     ms_table: table,
     chunk_size: int,
     data_column: str,
-    weight_column: str | None = None,
+    weights_column: str | None = None,
 ) -> Generator[DataChunkArray, None, None]:
     """Return an appropriately size data chunk from the main
     table of a measurement set. These data are ase they are
@@ -205,9 +206,9 @@ def _get_data_chunk_from_main_table(
         ant_2 = ms_table.getcol("ANTENNA2", startrow=lower_row, nrow=chunk_size)
 
         weights = None
-        if weight_column:
+        if weights_column:
             weights = ms_table.getcol(
-                weight_column, startrow=lower_row, nrow=chunk_size
+                weights_column, startrow=lower_row, nrow=chunk_size
             )
 
         yield DataChunkArray(
@@ -229,6 +230,7 @@ def get_data_chunks(
     open_ms_tables: OpenMSTables,
     chunk_size: int,
     data_column: str,
+    weights_column: str | None = None,
 ) -> Generator[DataChunk, None, None]:
     """Yield a collection of rows with appropriate units
     attached to the quantities. These quantities are not
@@ -240,6 +242,7 @@ def get_data_chunks(
         open_ms_tables (OpenMSTables): References to open tables from the measurement set
         chunk_size (int): The number of rows to return at a time
         data_column (str): The data column that would be modified
+        weights_column (str | None, optional): The weights column that would be modified if specified. Defaults to None.
 
     Yields:
         Generator[DataChunk, None, None]: Representation of the current chunk of rows
@@ -253,6 +256,7 @@ def get_data_chunks(
         ms_table=open_ms_tables.main_table,
         chunk_size=chunk_size,
         data_column=data_column,
+        weights_column=weights_column,
     ):
         # Transform the native arrays but attach astropy quantities
         uvws_phase_center = data_chunk_array.uvws * u.m
@@ -276,6 +280,7 @@ def get_data_chunks(
             ant_2=data_chunk_array.ant_2,
             row_start=data_chunk_array.row_start,
             chunk_size=data_chunk_array.chunk_size,
+            weights=data_chunk_array.weights,
         )
 
 
@@ -284,6 +289,7 @@ def get_multiple_data_chunks(
     chunk_size: int,
     data_column: str,
     number_of_chunks: int = 1,
+    weights_column: str | None = None,
 ) -> Generator[tuple[DataChunk, ...], None, None]:
     """
     Wrapper around ``get_data_chunks`` to yield a list of
@@ -300,6 +306,7 @@ def get_multiple_data_chunks(
         chunk_size (int): The number of rows to return at a time
         data_column (str): The data column that would be modified
         number_of_chunks (int, optional): The number of chunks to return on each yield. Defaults to 1.
+        weights_column (str | None, optional): The weights column that would be modified if specified. Defaults to None.
 
     Yields:
         Generator[tuple[DataChunk, ...], None, None]: Representation of the current chunk of rows
@@ -310,7 +317,10 @@ def get_multiple_data_chunks(
     # We are using the existing generator. Termination should be
     # straightforward.
     for data_chunk in get_data_chunks(
-        open_ms_tables=open_ms_tables, chunk_size=chunk_size, data_column=data_column
+        open_ms_tables=open_ms_tables,
+        chunk_size=chunk_size,
+        data_column=data_column,
+        weights_column=weights_column,
     ):
         base_chunks.append(data_chunk)
 
@@ -973,6 +983,10 @@ def tukey_tractor(
             open_ms_tables=open_ms_tables, tukey_tractor_options=tukey_tractor_options
         )
 
+    weights_column = set_weight_column(
+        ms_path=ms_path, weight_column=tukey_tractor_options.weight_column
+    )
+
     write_back_required: bool = True
     if not tukey_tractor_options.dry_run:
         # Data will need to be written back to the MS after each chunk if the
@@ -1022,6 +1036,7 @@ def tukey_tractor(
                 chunk_size=tukey_tractor_options.chunk_size,
                 data_column=tukey_tractor_options.data_column,
                 number_of_chunks=tukey_tractor_options.max_workers,
+                weights_column=weights_column,
             ):
                 start_tukey = time()
                 taper_data_and_flags: list[TaperedChunkResult] = []

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -969,6 +969,71 @@ def _set_auto_taper_widths(
     # TODO: Removing the type ignore above results in a mypy error in capn_crunch
 
 
+def write_back_results(
+    open_ms_tables: OpenMSTables,
+    taper_chunk_result: TaperedChunkResult,
+    tukey_tractor_options: TukeyTractorOptions,
+    write_back_required: bool,
+    pbar: tqdm | None = None,
+) -> None:
+    """Write back data chunk results to the measurement set
+
+    Args:
+        open_ms_tables (OpenMSTables): The set of open handlers to the relevant measurement sets
+        taper_chunk_result (TaperedChunkResult): The collect of results to consider around writing back
+        tukey_tractor_options (TukeyTractorOptions): Options relevant to the data selection
+        pbar (tqdm): A handler to the progress bar
+        write_back_required (bool): Whether a write back is required in all cases
+    """
+    if pbar is not None:
+        pbar.update(taper_chunk_result.chunk_size)
+
+    if taper_chunk_result.nothing_to_do and not write_back_required:
+        logger.debug("No attached data payload, skipping")
+        return
+
+    data_chunk = taper_chunk_result.data_chunk
+    assert data_chunk is not None, f"{data_chunk=}, which should not happen"
+
+    # Only update here is we pass the dry run check above. If data are not copied
+    # upfront for new column than this is necessary
+    if taper_chunk_result.update_data or write_back_required:
+        open_ms_tables.main_table.putcol(
+            columnname=tukey_tractor_options.output_column,
+            value=data_chunk.masked_data,
+            startrow=data_chunk.row_start,
+            nrow=data_chunk.chunk_size,
+        )
+    else:
+        logger.debug("No update of data required, skipping")
+    if taper_chunk_result.update_flags:
+        open_ms_tables.main_table.putcol(
+            columnname="FLAG",
+            value=taper_chunk_result.flags,
+            startrow=data_chunk.row_start,
+            nrow=data_chunk.chunk_size,
+        )
+    else:
+        logger.debug("No updating of flags required, skipping for chunk")
+    if taper_chunk_result.update_weights:
+        logger.debug("Updating weights")
+        assert taper_chunk_result.weights is not None, (
+            "Expected weights to be attached, found None"
+        )
+        for (
+            weight_column_name,
+            scaled_weights,
+        ) in taper_chunk_result.weights.items():
+            open_ms_tables.main_table.putcol(
+                columnname=weight_column_name,
+                value=scaled_weights,
+                startrow=data_chunk.row_start,
+                nrow=data_chunk.chunk_size,
+            )
+    else:
+        logger.debug("No updating of weights")
+
+
 def tukey_tractor(
     ms_path: Path,
     tukey_tractor_options: TukeyTractorOptions,
@@ -1092,61 +1157,19 @@ def tukey_tractor(
                 # for taper_data_chunk, flags_to_apply in taper_data_and_flags:
                 taper_chunk_result: TaperedChunkResult
                 for taper_chunk_result in taper_data_and_flags:
-                    pbar.update(taper_chunk_result.chunk_size)
-
-                    if taper_chunk_result.nothing_to_do and not write_back_required:
-                        logger.debug("No attached data payload, skipping")
-                        continue
-
-                    data_chunk = taper_chunk_result.data_chunk
-                    assert data_chunk is not None, (
-                        f"{data_chunk=}, which should not happen"
+                    write_back_results(
+                        open_ms_tables=open_ms_tables,
+                        taper_chunk_result=taper_chunk_result,
+                        tukey_tractor_options=tukey_tractor_options,
+                        write_back_required=write_back_required,
+                        pbar=pbar,
                     )
 
-                    # Only update here is we pass the dry run check above. If data are not copied
-                    # upfront for new column than this is necessary
-                    if taper_chunk_result.update_data or write_back_required:
-                        open_ms_tables.main_table.putcol(
-                            columnname=tukey_tractor_options.output_column,
-                            value=data_chunk.masked_data,
-                            startrow=data_chunk.row_start,
-                            nrow=data_chunk.chunk_size,
-                        )
-                    else:
-                        logger.debug("No update of data required, skipping")
-                    if taper_chunk_result.update_flags:
-                        open_ms_tables.main_table.putcol(
-                            columnname="FLAG",
-                            value=taper_chunk_result.flags,
-                            startrow=data_chunk.row_start,
-                            nrow=data_chunk.chunk_size,
-                        )
-                    else:
-                        logger.debug(
-                            "No updating of flags required, skipping for chunk"
-                        )
-                    if taper_chunk_result.update_weights:
-                        logger.debug("Updating weights")
-                        assert taper_chunk_result.weights is not None, (
-                            "Expected weights to be attached, found None"
-                        )
-                        for (
-                            weight_column_name,
-                            scaled_weights,
-                        ) in taper_chunk_result.weights.items():
-                            open_ms_tables.main_table.putcol(
-                                columnname=weight_column_name,
-                                value=scaled_weights,
-                                startrow=data_chunk.row_start,
-                                nrow=data_chunk.chunk_size,
-                            )
-                    else:
-                        logger.debug("No updating of weights")
         stop = time()
         runtime_s = stop - start
-        assert data_chunk is not None, "data_chunk is not formed correctly"
+        assert data_chunk_tuple[-1] is not None, "data_chunk is not formed correctly"
         logger.info(
-            f"Tapered {len(tukey_tractor_options.target_objects)} targets over {len(open_ms_tables.main_table)} rows by {len(data_chunk.freq_chan)} chans in {runtime_s:0.2f}s"
+            f"Tapered {len(tukey_tractor_options.target_objects)} targets over {len(open_ms_tables.main_table)} rows by {len(data_chunk_tuple[-1].freq_chan)} chans in {runtime_s:0.2f}s"
         )
 
         logger.info(

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -8,7 +8,7 @@ from functools import partial
 from itertools import combinations
 from pathlib import Path
 from time import time
-from typing import cast
+from typing import Any, cast
 
 import astropy.units as u
 import numpy as np
@@ -41,10 +41,10 @@ from jolly_roger.wrap import calculate_nyquist_zone, symmetric_domain_wrap
 
 
 def tukey_taper(
-    x: np.typing.NDArray[np.floating],
+    x: np.typing.NDArray[np.floating[Any]],
     outer_width: float,
     tukey_width: float,
-    tukey_x_offset: NDArray[np.floating] | None = None,
+    tukey_x_offset: NDArray[np.floating[Any]] | None = None,
 ) -> np.ndarray:
     """Describes a tukey window function spanning a -x.min() to x.max() range. In the base case
     the tukey window is centred on 0.0. The ``outer_width`` defines where the window is
@@ -60,10 +60,10 @@ def tukey_taper(
     Between these two bounds the window follows a `1 - cos` type shape.
 
     Args:
-        x (np.typing.NDArray[np.floating]): The intervals to evaluate over. Internally these are concerted to the +/- pi domain
+        x (np.typing.NDArray[np.floating[Any]]): The intervals to evaluate over. Internally these are concerted to the +/- pi domain
         outer_width (float, optional): The +/- boundary beyond which is 0.0.
         tukey_width (float, optional): Describes the width that the transition from 1.0 to 0.0 occurs.
-        tukey_x_offset (NDArray[np.floating] | None, optional): Sets a new zero point (center of window). Defaults to None.
+        tukey_x_offset (NDArray[np.floating[Any]] | None, optional): Sets a new zero point (center of window). Defaults to None.
         notch (bool, optional): Will the taper be used for a notch filter? Defaults to True.
 
     Returns:
@@ -118,9 +118,9 @@ class DataChunkArray:
     """The data from the nominated data column loaded"""
     flags: NDArray[np.bool_]
     """Flags that correspond to the loaded data"""
-    uvws: NDArray[np.floating]
+    uvws: NDArray[np.floating[Any]]
     """The uvw coordinates for each loaded data record"""
-    time_centroid: NDArray[np.floating]
+    time_centroid: NDArray[np.floating[Any]]
     """The time of each data record"""
     ant_1: NDArray[np.int64]
     """Antenna 1 that formed the baseline"""
@@ -130,7 +130,7 @@ class DataChunkArray:
     """The starting row of the portion of data loaded"""
     chunk_size: int
     """The size of the data chunk loaded (may be larger if this is the last record)"""
-    weights: dict[str, NDArray[np.floating]] | None = None
+    weights: dict[str, NDArray[np.floating[Any]]] | None = None
     """The weights associated with the data. Key is the column name and the mapped value are the corresponding weights. Only used if reweighting is activated. Defaults to None."""
 
 
@@ -150,7 +150,7 @@ class DataChunk:
     """The UVW coordinates of the phase center of the baseline."""
     time: Time
     """The time of the observations."""
-    time_mjds: NDArray[np.floating]
+    time_mjds: NDArray[np.floating[Any]]
     """The raw time extracted from the measurement set in MJDs"""
     ant_1: NDArray[np.int64]
     """The first antenna in the baseline."""
@@ -160,7 +160,7 @@ class DataChunk:
     """Starting row index of the data"""
     chunk_size: int
     """Size of the chunked portion of the data"""
-    weights: dict[str, NDArray[np.floating]] | None = None
+    weights: dict[str, NDArray[np.floating[Any]]] | None = None
     """The weights associated with the data. Key is the column name and the mapped value are the corresponding weights. Only used if reweighting is activated. Defaults to None."""
 
 
@@ -550,7 +550,7 @@ class TaperResult:
 
     attached_payload: bool = False
     """Indicates whether anything to do."""
-    taper: NDArray[np.floating] | None = None
+    taper: NDArray[np.floating[Any]] | None = None
     """The taper to apply. If None nothing to do."""
     update_flags: bool = False
     """Indicates whether flags need to be updated"""
@@ -768,7 +768,7 @@ class TaperedChunkResult:
     """The flags to write back"""
     update_weights: bool = False
     """Indicates whether data should be written back to the MS"""
-    weights: dict[str, NDArray[np.floating]] | None = None
+    weights: dict[str, NDArray[np.floating[Any]]] | None = None
     """The scaled weights that should be written back to the MS. The key is the column name and the mapped values are the corresponding scaled weights. If None nothing to write back."""
 
 
@@ -860,7 +860,7 @@ def _tukey_multi_tractor(
     # need to be scaleded based on the final taper. The driving functions that
     # call into this multi tractor are responsible to writing this back out to
     # the appropriate coluumn
-    scaled_weights: None | dict[str, NDArray[np.floating]] = None
+    scaled_weights: None | dict[str, NDArray[np.floating[Any]]] = None
     update_weights = False
     if data_chunk.weights is not None:
         scaled_weights = scale_multiple_weights(

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -205,7 +205,7 @@ def _get_data_chunk_from_main_table(
         ant_1 = ms_table.getcol("ANTENNA1", startrow=lower_row, nrow=chunk_size)
         ant_2 = ms_table.getcol("ANTENNA2", startrow=lower_row, nrow=chunk_size)
 
-        weights = None
+        weights: None | dict[str, NDArray[np.floating[Any]]] = None
         if weight_columns:
             weights = {
                 weight_column: ms_table.getcol(

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -1118,6 +1118,7 @@ def tukey_tractor(
                             "No updating of flags required, skipping for chunk"
                         )
                     if taper_chunk_result.update_weights:
+                        logger.info("Updating weights")
                         open_ms_tables.main_table.putcol(
                             columnname=weights_column,
                             value=taper_chunk_result.weights,

--- a/jolly_roger/uvws.py
+++ b/jolly_roger/uvws.py
@@ -40,10 +40,28 @@ class WDelays:
 def get_object_delay_for_ms(
     ms_path: Path,
     phase_dir: SkyCoord,
-    object_name: str | list[str] | tuple[str, ...] = "sun",
+    object_name: str
+    | SkyCoord
+    | list[str | SkyCoord]
+    | tuple[str | SkyCoord, ...] = "sun",
     reverse_baselines: bool = False,
     flip_uvw_sign: bool = False,
 ) -> list[WDelays]:
+    """Calculate the delay between the phase-direction in the measuurement and a set of object directions.
+    The delay is calculated by computing the UVWs in both directions and examining the difference in the
+    w-term.
+
+    Args:
+        ms_path (Path): The measurement set and associated meta-data
+        phase_dir (SkyCoord): The phase direction (this couuls be more broadly considered direction 1)
+        object_name (str | SkyCoord | list[str  |  SkyCoord] | tuple[str  |  SkyCoord, ...], optional): The collection of other sky positions to calculate the delays towards. Defaults to "sun".
+        reverse_baselines (bool, optional): Whether the MS has antennas recorded as (ant1, ant2) or (ant2, ant1), where ant2 is always larger. Defaults to False.
+        flip_uvw_sign (bool, optional): Indicates whether a sign slip needs to be introduced to the UVWs. Defaults to False.
+
+    Returns:
+        list[WDelays]: Description of the delay towards the nominated object. A list of objects will always be returned.
+    """
+
     object_name = [object_name] if isinstance(object_name, str) else object_name
     assert isinstance(object_name, list | tuple), (
         f"Expected type list | tuple, got {type(object_name)=}"

--- a/jolly_roger/uvws.py
+++ b/jolly_roger/uvws.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -40,10 +41,7 @@ class WDelays:
 def get_object_delay_for_ms(
     ms_path: Path,
     phase_dir: SkyCoord,
-    object_name: str
-    | SkyCoord
-    | list[str | SkyCoord]
-    | tuple[str | SkyCoord, ...] = "sun",
+    object_name: str | SkyCoord | Sequence[str | SkyCoord] = "sun",
     reverse_baselines: bool = False,
     flip_uvw_sign: bool = False,
 ) -> list[WDelays]:
@@ -54,7 +52,7 @@ def get_object_delay_for_ms(
     Args:
         ms_path (Path): The measurement set and associated meta-data
         phase_dir (SkyCoord): The phase direction (this couuls be more broadly considered direction 1)
-        object_name (str | SkyCoord | list[str  |  SkyCoord] | tuple[str  |  SkyCoord, ...], optional): The collection of other sky positions to calculate the delays towards. Defaults to "sun".
+        object_name (str | SkyCoord | Sequence[str  |  SkyCoord], optional): The collection of other sky positions to calculate the delays towards. Defaults to "sun".
         reverse_baselines (bool, optional): Whether the MS has antennas recorded as (ant1, ant2) or (ant2, ant1), where ant2 is always larger. Defaults to False.
         flip_uvw_sign (bool, optional): Indicates whether a sign slip needs to be introduced to the UVWs. Defaults to False.
 

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -97,6 +97,8 @@ def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floa
     Returns:
         NDArray[np.floating]: The scaling terms to adjust weights by. The more data that is nulled the higher the returned value becomes
     """
+    taper = np.squezze(taper)
+
     # Basic checks around the taper
     assert taper.ndim == 2, f"Expectede a 2D array, got {taper.shape=}"
     assert np.min(taper) >= 0.0, "Taper appears to be less than zero"

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -25,36 +25,39 @@ def _get_column_names(ms_path: Path) -> Sequence[str]:
     return columns
 
 
-def find_weight_column(ms_path: Path) -> str | None:
+def find_weight_columns(ms_path: Path) -> Sequence[str] | None:
     """Examine the column names in the MS in order to find
-    a WEIGHT-like column. The column names are drawn from
+    WEIGHT-like columns. The column names are drawn from
     a list of recognised column names that may contain WEUGHTS.
 
     Args:
         ms_path (Path): Path to the measurement set
 
     Returns:
-        str | None: The name of the WEIGHT-like column. If not found None is returned.
+        Sequence[str] | None: The names of the WEIGHT-like column. If not found None is returned.
     """
     logger.info("Searching for WEIGHT-like column")
 
-    weight_column: str | None = None
     columns = _get_column_names(ms_path)
+    weight_columns = [col for col in KNOWN_WEIGHTS if col in columns]
 
-    for col in KNOWN_WEIGHTS:
-        if col in columns:
-            weight_column = col
-            break
+    if len(columns) == 0:
+        logger.info("No WEIGHT-like columns were found.")
+        return None
 
-    logger.info(f"Found WEIGHT-like column {weight_column=}")
-    return weight_column
+    logger.info(f"Found WEIGHT-like column {weight_columns=}")
+    return weight_columns
 
 
-def select_weight_column(ms_path: Path, weight_column: str | None = None) -> str | None:
-    """Establish a WEIGHT-like column from provided options. If ``weight_column``
-    is set then verify it exists in the pfovided measurement set. If it is not
-    then the columns in the measurement set are examined for a recognised
-    WEIGHT-like column.
+def select_weight_column(
+    ms_path: Path, weight_column: str | None = None
+) -> Sequence[str] | None:
+    """Establishes the set ofWEIGHT-like column from provided options.
+
+    Known WEIGHT-like column names will be examined to see if they are present in
+    the MS. Multiple columns may be returned in more than one are found. Otherwise
+    a single ``weight_column`` may be provided, and if found to be valid, will
+    overwrite the recognised columns.
 
     Args:
         ms_path (Path): The measurement set to consider
@@ -64,7 +67,7 @@ def select_weight_column(ms_path: Path, weight_column: str | None = None) -> str
         ValueError: Raised if ``weight_column`` is provided but does not exist
 
     Returns:
-        str | None: Name of the WEIGHT-like column if found or set. If not found None is returned.
+        Sequence[str] | None: Names of the WEIGHT-like column if found or set. If not found None is returned.
     """
 
     if weight_column:
@@ -77,9 +80,9 @@ def select_weight_column(ms_path: Path, weight_column: str | None = None) -> str
             raise ValueError(msg)
 
         logger.info(f"Using specified {weight_column=} as WEIGHT-like column")
-        return weight_column
+        return [weight_column]
 
-    return find_weight_column(ms_path=ms_path)
+    return find_weight_columns(ms_path=ms_path)
 
 
 def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floating]:
@@ -117,6 +120,7 @@ def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floa
 def scale_weights(
     taper: NDArray[np.floating],
     weights: NDArray[np.floating],
+    taper_is_scale: bool = False,
 ) -> NDArray[np.floating]:
     """Accept the taper array and associated set of weights, and appropriately
     scale the weights based on the amount of data nulled. The weights here could
@@ -134,6 +138,7 @@ def scale_weights(
     Args:
         taper (NDArray[np.floating]): The two-dimensional taper that will be applied to data
         weights (NDArray[np.floating]): The extract weights column
+        taper_is_scale (bool, optional): Indicates whether the input ``taper`` has already been t ransformed to a scaling term. Defaults to False.
 
     Raises:
         ValueError: Raised when the supplied weight have a rank that is neither 1 or 2
@@ -141,8 +146,8 @@ def scale_weights(
     Returns:
         NDArray[np.floating]: Scaled weights that should be inserted to the measuremenset set
     """
-
-    scale = calculate_scaling_from_taper(taper=taper)
+    # The scale could be already derieved should multi-ple columns need scaling
+    scale = calculate_scaling_from_taper(taper=taper) if not taper_is_scale else taper
 
     scaled_weights: None | NDArray[np.floating] = None
     # Appropriately handle potential broadcasting issues, e.g. WEIGHT vs WEIGHT_SPECTRUM
@@ -158,3 +163,40 @@ def scale_weights(
 
     assert scaled_weights is not None, "Scaled weights appears unset"
     return scaled_weights
+
+
+def scale_multiple_weights(
+    taper: NDArray[np.floating],
+    weights: dict[str, NDArray[np.floating]],
+) -> dict[str, NDArray[np.floating]]:
+    """Accept the taper array and associated set of weights, and appropriately
+    scale the weights based on the amount of data nulled. The weights here could
+    take a couple of forms:
+
+    - WEIGHT: a single value for a collection of rows
+    - WEIGHT_SPECTRUM: A spectrum of weight values (e.g. channel weights) across a collection of rows
+
+    The taper is assumed to be the Notch filter, with a smooth roll off, and in the 0 to 1 range. Where
+    data is nulled (closer to 0) the weights will increase. Since the taper is intended to be applied
+    in delay space and then subsequently inverted to visibilities, the weights are simply scaled in a
+    pure multiplicative sense. In either the WEIGHT or WEIGHT_SPECTRUM scale a single scalar is used to
+    scale a single row.
+
+    Args:
+        taper (NDArray[np.floating]): The two-dimensional taper that will be applied to data
+        weights (dict[str, NDArray[np.floating]]): The extract weights column. For each key (representing the column name) scakle the mapped data (the weights)
+
+    Returns:
+        dict[str, NDArray[np.floating]]: Scaled weights that should be inserted to the measuremenset set. The output shape will represent the scaled input ``weights``
+    """
+
+    assert isinstance(weights, dict), (
+        f"Expected weights to be a dictionary, got {type(weights)}"
+    )
+
+    scale = calculate_scaling_from_taper(taper=taper)
+
+    return {
+        k: scale_weights(taper=scale, weights=weights[k], taper_is_scale=True)
+        for k in weights
+    }

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -97,6 +97,8 @@ def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floa
     Returns:
         NDArray[np.floating]: The scaling terms to adjust weights by. The more data that is nulled the higher the returned value becomes
     """
+    # The aper can be (rows, channels, pols), where pols is really length 1 but is reshaped
+    # accordingly to t the recorded MS data column polarisations
     taper = np.squeeze(taper)
 
     # Basic checks around the taper

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -19,7 +19,7 @@ def _get_column_names(ms_path: Path) -> Sequence[str]:
     """A dumb helper to avoid duplication"""
     assert ms_path.exists(), f"MS file {ms_path} does not exist"
 
-    with table(str(ms_path)) as tab:
+    with table(str(ms_path), ack=False, readonly=True) as tab:
         columns: Sequence[str] = tab.colnames()
 
     return columns

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from casacore.tables import table
@@ -85,7 +86,9 @@ def select_weight_columns(
     return find_weight_columns(ms_path=ms_path)
 
 
-def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floating]:
+def calculate_scaling_from_taper(
+    taper: NDArray[np.floating[Any]],
+) -> NDArray[np.floating[Any]]:
     """The taper applied in delay space is essentially a Notch filter, which
     has been implemented to have a smooth Gaussian roll off. This will calculate
     the ratio of modified data and return an appropriate scaling term to indicate
@@ -95,10 +98,10 @@ def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floa
     The more data that is nulled the larger this term becomes.
 
     Args:
-        taper (NDArray[np.floating]): The taper that will be applied
+        taper (NDArray[np.floating[Any]]): The taper that will be applied
 
     Returns:
-        NDArray[np.floating]: The scaling terms to adjust weights by. The more data that is nulled the higher the returned value becomes
+        NDArray[np.floating[Any]]: The scaling terms to adjust weights by. The more data that is nulled the higher the returned value becomes
     """
     # The aper can be (rows, channels, pols), where pols is really length 1 but is reshaped
     # accordingly to t the recorded MS data column polarisations
@@ -118,10 +121,10 @@ def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floa
 
 
 def scale_weights(
-    taper: NDArray[np.floating],
-    weights: NDArray[np.floating],
+    taper: NDArray[np.floating[Any]],
+    weights: NDArray[np.floating[Any]],
     taper_is_scale: bool = False,
-) -> NDArray[np.floating]:
+) -> NDArray[np.floating[Any]]:
     """Accept the taper array and associated set of weights, and appropriately
     scale the weights based on the amount of data nulled. The weights here could
     take a couple of forms:
@@ -136,20 +139,20 @@ def scale_weights(
     scale a single row.
 
     Args:
-        taper (NDArray[np.floating]): The two-dimensional taper that will be applied to data
-        weights (NDArray[np.floating]): The extract weights column
+        taper (NDArray[np.floating[Any]]): The two-dimensional taper that will be applied to data
+        weights (NDArray[np.floating[Any]]): The extract weights column
         taper_is_scale (bool, optional): Indicates whether the input ``taper`` has already been t ransformed to a scaling term. Defaults to False.
 
     Raises:
         ValueError: Raised when the supplied weight have a rank that is neither 1 or 2
 
     Returns:
-        NDArray[np.floating]: Scaled weights that should be inserted to the measuremenset set
+        NDArray[np.floating[Any]]: Scaled weights that should be inserted to the measuremenset set
     """
     # The scale could be already derieved should multi-ple columns need scaling
     scale = calculate_scaling_from_taper(taper=taper) if not taper_is_scale else taper
 
-    scaled_weights: None | NDArray[np.floating] = None
+    scaled_weights: None | NDArray[np.floating[Any]] = None
     # Appropriately handle potential broadcasting issues, e.g. WEIGHT vs WEIGHT_SPECTRUM
     if weights.ndim == 1:
         # No broadcasting is needed
@@ -166,9 +169,9 @@ def scale_weights(
 
 
 def scale_multiple_weights(
-    taper: NDArray[np.floating],
-    weights: dict[str, NDArray[np.floating]],
-) -> dict[str, NDArray[np.floating]]:
+    taper: NDArray[np.floating[Any]],
+    weights: dict[str, NDArray[np.floating[Any]]],
+) -> dict[str, NDArray[np.floating[Any]]]:
     """Accept the taper array and associated set of weights, and appropriately
     scale the weights based on the amount of data nulled. The weights here could
     take a couple of forms:
@@ -183,11 +186,11 @@ def scale_multiple_weights(
     scale a single row.
 
     Args:
-        taper (NDArray[np.floating]): The two-dimensional taper that will be applied to data
-        weights (dict[str, NDArray[np.floating]]): The extract weights column. For each key (representing the column name) scakle the mapped data (the weights)
+        taper (NDArray[np.floating[Any]]): The two-dimensional taper that will be applied to data
+        weights (dict[str, NDArray[np.floating[Any]]]): The extract weights column. For each key (representing the column name) scakle the mapped data (the weights)
 
     Returns:
-        dict[str, NDArray[np.floating]]: Scaled weights that should be inserted to the measuremenset set. The output shape will represent the scaled input ``weights``
+        dict[str, NDArray[np.floating[Any]]]: Scaled weights that should be inserted to the measuremenset set. The output shape will represent the scaled input ``weights``
     """
 
     assert isinstance(weights, dict), (

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from pathlib import Path
 
+import numpy as np
 from casacore.tables import table
+from numpy.typing import NDArray
 
 from jolly_roger.logging import logger
 
@@ -48,7 +50,7 @@ def find_weight_column(ms_path: Path) -> str | None:
     return weight_column
 
 
-def set_weight_column(ms_path: Path, weight_column: str | None = None) -> str | None:
+def select_weight_column(ms_path: Path, weight_column: str | None = None) -> str | None:
     """Establish a WEIGHT-like column from provided options. If ``weight_column``
     is set then verify it exists in the pfovided measurement set. If it is not
     then the columns in the measurement set are examined for a recognised
@@ -78,3 +80,77 @@ def set_weight_column(ms_path: Path, weight_column: str | None = None) -> str | 
         return weight_column
 
     return find_weight_column(ms_path=ms_path)
+
+
+def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floating]:
+    """The taper applied in delay space is essentially a Notch filter, which
+    has been implemented to have a smooth Gaussian roll off. This will calculate
+    the ratio of modified data and return an appropriate scaling term to indicate
+    the amount of information nulled away.
+
+    The returned scaling is a multimplicative term that should be applied to the weight column.
+    The more data that is nulled the larger this term becomes.
+
+    Args:
+        taper (NDArray[np.floating]): The taper that will be applied
+
+    Returns:
+        NDArray[np.floating]: The scaling terms to adjust weights by. The more data that is nulled the higher the returned value becomes
+    """
+    # Basic checks around the taper
+    assert taper.ndim == 2, f"Expectede a 2D array, got {taper.shape=}"
+    assert np.min(taper) >= 0.0, "Taper appears to be less than zero"
+    assert np.max(taper) <= 1.0, "Taper appears to be larger than one"
+
+    # The taper should be of shape (row, signal), where row is simply the
+    # index into the MS data table
+    signal_length = taper.shape[1]
+    signal = np.sum(taper, axis=1)
+    signal[signal == 0] += 1  # Avoid divide by zero
+    return signal_length / signal
+
+
+def scale_weights(
+    taper: NDArray[np.floating],
+    weights: NDArray[np.floating],
+) -> NDArray[np.floating]:
+    """Accept the taper array and associated set of weights, and appropriately
+    scale the weights based on the amount of data nulled. The weights here could
+    take a couple of forms:
+
+    - WEIGHT: a single value for a collection of rows
+    - WEIGHT_SPECTRUM: A spectrum of weight values (e.g. channel weights) across a collection of rows
+
+    The taper is assumed to be the Notch filter, with a smooth roll off, and in the 0 to 1 range. Where
+    data is nulled (closer to 0) the weights will increase. Since the taper is intended to be applied
+    in delay space and then subsequently inverted to visibilities, the weights are simply scaled in a
+    pure multiplicative sense. In either the WEIGHT or WEIGHT_SPECTRUM scale a single scalar is used to
+    scale a single row.
+
+    Args:
+        taper (NDArray[np.floating]): The two-dimensional taper that will be applied to data
+        weights (NDArray[np.floating]): The extract weights column
+
+    Raises:
+        ValueError: Raised when the supplied weight have a rank that is neither 1 or 2
+
+    Returns:
+        NDArray[np.floating]: Scaled weights that should be inserted to the measuremenset set
+    """
+
+    scale = calculate_scaling_from_taper(taper=taper)
+
+    scaled_weights: None | NDArray[np.floating] = None
+    # Appropriately handle potential broadcasting issues, e.g. WEIGHT vs WEIGHT_SPECTRUM
+    if weights.ndim == 1:
+        # No broadcasting is needed
+        scaled_weights = weights * scale
+    elif weights.ndim == 2:
+        # The shape should be [row, channel], and the scaling will be per-channel
+        scaled_weights = weights * scale[:, None]
+    else:
+        msg = f"Can only handle 1D or 2D weights, got {weights.shape=}"
+        raise ValueError(msg)
+
+    assert scaled_weights is not None, "Scaled weights appears unset"
+    return scaled_weights

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -1,0 +1,39 @@
+"""Utility functions to help direct the rescaling of weight like
+columns"""
+
+from pathlib import Path
+
+from casacore.tables import table
+
+from jolly_roger.logging import logger
+
+
+
+KNOWN_WEIGHTS = (
+    "WEIGHT",
+    "WEIGHT_SPECTRUM"
+)
+
+def find_weight_column(
+    ms_path: Path
+) -> str:
+    logger.info("Searching for WEIGHT-like column")
+    
+    assert ms_path.exists(), f"MS file {ms_path} does not exist"
+    
+    weight_column: str | None = None
+    
+    with table(str(ms_path)) as tab:
+        columns = tab.colnames()
+        
+    for col in KNOWN_WEIGHTS:
+        if col in columns:
+            weight_column = col
+            break
+        
+    if weight_column is None:
+        msg = f"Searched for {KNOWN_WEIGHTS=} but found none in {ms_path=}"
+        raise ValueError(msg)
+
+    logger.info(f"Found WEIGHT-like column {weight_column=}")
+    return weight_column

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -74,6 +74,7 @@ def set_weight_column(ms_path: Path, weight_column: str | None = None) -> str | 
             msg = f"Specified {weight_column=} not found in {columns=}"
             raise ValueError(msg)
 
+        logger.info(f"Using specified {weight_column=} as WEIGHT-like column")
         return weight_column
 
     return find_weight_column(ms_path=ms_path)

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -97,7 +97,7 @@ def calculate_scaling_from_taper(taper: NDArray[np.floating]) -> NDArray[np.floa
     Returns:
         NDArray[np.floating]: The scaling terms to adjust weights by. The more data that is nulled the higher the returned value becomes
     """
-    taper = np.squezze(taper)
+    taper = np.squeeze(taper)
 
     # Basic checks around the taper
     assert taper.ndim == 2, f"Expectede a 2D array, got {taper.shape=}"

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -1,39 +1,79 @@
 """Utility functions to help direct the rescaling of weight like
 columns"""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
 from pathlib import Path
 
 from casacore.tables import table
 
 from jolly_roger.logging import logger
 
+KNOWN_WEIGHTS = ("WEIGHT", "WEIGHT_SPECTRUM")
 
 
-KNOWN_WEIGHTS = (
-    "WEIGHT",
-    "WEIGHT_SPECTRUM"
-)
-
-def find_weight_column(
-    ms_path: Path
-) -> str:
-    logger.info("Searching for WEIGHT-like column")
-    
+def _get_column_names(ms_path: Path) -> Sequence[str]:
+    """A dumb helper to avoid duplication"""
     assert ms_path.exists(), f"MS file {ms_path} does not exist"
-    
-    weight_column: str | None = None
-    
+
     with table(str(ms_path)) as tab:
-        columns = tab.colnames()
-        
+        columns: Sequence[str] = tab.colnames()
+
+    return columns
+
+
+def find_weight_column(ms_path: Path) -> str | None:
+    """Examine the column names in the MS in order to find
+    a WEIGHT-like column. The column names are drawn from
+    a list of recognised column names that may contain WEUGHTS.
+
+    Args:
+        ms_path (Path): Path to the measurement set
+
+    Returns:
+        str | None: The name of the WEIGHT-like column. If not found None is returned.
+    """
+    logger.info("Searching for WEIGHT-like column")
+
+    weight_column: str | None = None
+    columns = _get_column_names(ms_path)
+
     for col in KNOWN_WEIGHTS:
         if col in columns:
             weight_column = col
             break
-        
-    if weight_column is None:
-        msg = f"Searched for {KNOWN_WEIGHTS=} but found none in {ms_path=}"
-        raise ValueError(msg)
 
     logger.info(f"Found WEIGHT-like column {weight_column=}")
     return weight_column
+
+
+def set_weight_column(ms_path: Path, weight_column: str | None = None) -> str | None:
+    """Establish a WEIGHT-like column from provided options. If ``weight_column``
+    is set then verify it exists in the pfovided measurement set. If it is not
+    then the columns in the measurement set are examined for a recognised
+    WEIGHT-like column.
+
+    Args:
+        ms_path (Path): The measurement set to consider
+        weight_column (str | None, optional): The specified weight column to use. Defaults to None.
+
+    Raises:
+        ValueError: Raised if ``weight_column`` is provided but does not exist
+
+    Returns:
+        str | None: Name of the WEIGHT-like column if found or set. If not found None is returned.
+    """
+
+    if weight_column:
+        columns = _get_column_names(ms_path=ms_path)
+
+        # If the user requested a column that does not exist
+        # we hit them with an error, mate
+        if weight_column not in columns:
+            msg = f"Specified {weight_column=} not found in {columns=}"
+            raise ValueError(msg)
+
+        return weight_column
+
+    return find_weight_column(ms_path=ms_path)

--- a/jolly_roger/weights.py
+++ b/jolly_roger/weights.py
@@ -49,7 +49,7 @@ def find_weight_columns(ms_path: Path) -> Sequence[str] | None:
     return weight_columns
 
 
-def select_weight_column(
+def select_weight_columns(
     ms_path: Path, weight_column: str | None = None
 ) -> Sequence[str] | None:
     """Establishes the set ofWEIGHT-like column from provided options.

--- a/jolly_roger/wrap.py
+++ b/jolly_roger/wrap.py
@@ -5,23 +5,24 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
 
 
 def symmetric_domain_wrap(
-    values: NDArray[np.floating], upper_limit: float
-) -> NDArray[np.floating]:
+    values: NDArray[np.floating[Any]], upper_limit: float
+) -> NDArray[np.floating[Any]]:
     """Place a set of values into a cyclic domain that is
     symmetric around zero.
 
     Args:
-        values (NDArray[np.floating]): Values that need to be mapped into the cyclic domain
+        values (NDArray[np.floating[Any]]): Values that need to be mapped into the cyclic domain
         upper_limit (float): The upper bound of the symmetric cyclic domain
 
     Returns:
-        NDArray[np.floating]: Values that have been mapped to the -upper_limit to upper_limit domain
+        NDArray[np.floating[Any]]: Values that have been mapped to the -upper_limit to upper_limit domain
     """
     # Calculate an appropriate domain mapping
     # The natural domain is going to be mapped
@@ -37,13 +38,13 @@ def symmetric_domain_wrap(
 
 
 def calculate_nyquist_zone(
-    values: NDArray[np.floating], upper_limit: float
+    values: NDArray[np.floating[Any]], upper_limit: float
 ) -> NDArray[np.int_]:
     """Return the nyquist zone a value is in for a symmetric
     set of bounds around zero
 
     Args:
-        values (NDArray[np.floating]): The values to calculate the zone for
+        values (NDArray[np.floating[Any]]): The values to calculate the zone for
         upper_limit (float): The upper bound to the symmetric domain around zero
 
     Returns:
@@ -56,7 +57,7 @@ def calculate_nyquist_zone(
 
 @dataclass
 class SymmetricWrap:
-    values: NDArray[np.floating]
+    values: NDArray[np.floating[Any]]
     """The wrapped values"""
     zones: NDArray[np.int_]
     """The nyquist zones for the wrapped data"""
@@ -65,12 +66,12 @@ class SymmetricWrap:
 
 
 def calculate_wrapped_data(
-    values: NDArray[np.floating], upper_limit: float
+    values: NDArray[np.floating[Any]], upper_limit: float
 ) -> SymmetricWrap:
     """Helper function to wrap data in a symmetric and cyclic domain.
 
     Args:
-        values (NDArray[np.floating]): The values to wrap
+        values (NDArray[np.floating[Any]]): The values to wrap
         upper_limit (float): The nyquist zone of the wrapped data
 
     Returns:

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,0 +1,119 @@
+"""Tests to do with the weights, their idenitiication
+and modification based on tapered properties"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from jolly_roger.weights import (
+    calculate_scaling_from_taper,
+    scale_multiple_weights,
+    scale_weights,
+)
+
+
+def test_scale_multiple_weights() -> None:
+    """Provided a collection of column and WEIGHT mappings, scale each of them
+    and return the result. This is essentially a super set of the tests below"""
+
+    weights_dict = {}
+    for column in ("WEIGHTS", "WEIGHT_SPECTRUM"):
+        weight_spectrum = np.zeros((256, 100))
+        for i in range(256):
+            weight_spectrum[i, :] = i + 1
+
+        weights_dict[column] = weight_spectrum
+
+    assert len(weights_dict) == 2
+
+    taper = np.ones((256, 100))
+    scaled_weights_dict = scale_multiple_weights(taper=taper, weights=weights_dict)
+
+    for column, weights in weights_dict.items():
+        assert np.all(weights == scaled_weights_dict[column])
+
+    taper_1 = taper.copy()
+    taper_1[100, 50:] = 0
+    scaled_weights_dict = scale_multiple_weights(taper=taper_1, weights=weights_dict)
+
+    for _column, scaled_weights in weights_dict.items():
+        assert np.all(scaled_weights[100] == 202)
+        for i in range(100):
+            assert np.all(scaled_weights[i] == i + 1)
+
+        for i in range(101, 256):
+            assert np.all(scaled_weights[i] == i + 1)
+
+
+def test_scale_weights_with_weight_spectrum() -> None:
+    """Attempt to scale a WEIGHT_SPECTRUM based on the taper. The WEIGHT_SPECTRUM is
+    of a shape (row, SPECTRUM)"""
+
+    weight_spectrum = np.zeros((256, 100))
+    for i in range(256):
+        weight_spectrum[i, :] = i + 1
+
+    taper = np.ones((256, 100))
+    scaled_weights = scale_weights(taper=taper, weights=weight_spectrum)
+    assert np.all(scaled_weights == weight_spectrum)
+
+    taper_1 = taper.copy()
+    taper_1[100, 50:] = 0
+    scaled_weights = scale_weights(taper=taper_1, weights=weight_spectrum)
+
+    assert np.all(scaled_weights[100] == 202)
+    for i in range(100):
+        assert np.all(scaled_weights[i] == i + 1)
+
+    for i in range(101, 256):
+        assert np.all(scaled_weights[i] == i + 1)
+
+
+def test_scale_weights_with_single_value_weight() -> None:
+    """Ensure that the weights are appropriately scaled based on the aggressiveness of the taper.
+    In this case the weights are not a weight spectrum, but the less informative WEIGHT where all channels
+    are weighted equally.
+    """
+
+    weights = np.zeros(256) + 50.0
+    taper = np.ones((256, 100))
+    scaled_weights = scale_weights(taper=taper, weights=weights)
+
+    # Since no nulling the weights should remain the same
+    assert np.all(scaled_weights == weights)
+
+    taper_1 = taper.copy()
+    taper_1[100, 50:] = 0
+    scaled_weights = scale_weights(taper=taper_1, weights=weights)
+
+    assert scaled_weights[100] == 100
+    assert np.all(scaled_weights[:100] == 50)
+    assert np.all(scaled_weights[101:] == 50)
+
+
+def test_calculate_scaling_from_taper() -> None:
+    """Deriving the scale from the tapering to apply to weights"""
+
+    all_ones = np.ones((256, 100))
+    scale = calculate_scaling_from_taper(taper=all_ones)
+
+    assert scale.ndim == 1
+    assert np.all(scale == 1)
+
+    example = all_ones.copy()
+    example[100, 50:] = 0
+
+    scale = calculate_scaling_from_taper(taper=example)
+    assert scale.ndim == 1
+    assert scale[100] == 2
+    assert np.all(scale[:100] == 1)
+    assert np.all(scale[101:] == 1)
+
+    example2 = all_ones.copy()
+    example2[100, :] = 0
+
+    scale = calculate_scaling_from_taper(taper=example2)
+    assert scale.ndim == 1
+    assert scale[100] == 100
+    assert np.all(scale[:100] == 1)
+    assert np.all(scale[101:] == 1)

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -36,7 +36,7 @@ def test_scale_multiple_weights() -> None:
     taper_1[100, 50:] = 0
     scaled_weights_dict = scale_multiple_weights(taper=taper_1, weights=weights_dict)
 
-    for _column, scaled_weights in weights_dict.items():
+    for _column, scaled_weights in scaled_weights_dict.items():
         assert np.all(scaled_weights[100] == 202)
         for i in range(100):
             assert np.all(scaled_weights[i] == i + 1)


### PR DESCRIPTION
The `jolly_tractor tukey` program will apply a null towards the direction of a set of sources, which is throwing away information. Therefore the corresponding set of weights should be modified to indicate that there is less signal in the data. 

This PR aims to:
- identify a weight column, or accept an explicit weight column
- construct a scaling term to apply to the set of weights that correspond to the data
- apply the scaling to the weights, and write back when necessary

I have tried to be consistent with our newer 'write back on change' approach.  