### PR TITLE
Fix to the taper slicing

### DIFF
--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -693,7 +693,7 @@ def _tukey_tractor(
 
         _field_taper = np.squeeze(field_taper)
         field_stats = np.max(abs_delay_time * (1.0 - _field_taper), axis=1)
-        object_stats = np.max(abs_delay_time * (1.0 - taper), axis=1)
+        object_stats = np.max(abs_delay_time * (1.0 - taper[..., 0]), axis=1)
 
         if tukey_tractor_options.compare_to_field is not None:
             flux_mask = (


### PR DESCRIPTION
In the previous PR I misunderstood my own code. It was captured for clarification by @AlecThomson  but I botched it. 

The t aper shape at that point is `[NChannels, chunk_size, pol]`, and the pol dimension was of size 1, but broadcasted against all polarisation in the data chunk array. 
