### PR TITLE
Search for object peak in delay space

### DIFF
--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -721,7 +721,7 @@ def compute_tukey_taper(
             x=delay_time.delay, object_delays=tukey_x_offset_sec * u.s
         )
 
-        if tukey_tractor_options.peak_shift_seach_width_ns is None:
+        if tukey_tractor_options.peak_shift_search_width_ns is None:
             # This isolates the spectrum of the source in delay space
             inverted_taper = (1.0 - taper)[..., 0]
 
@@ -735,8 +735,13 @@ def compute_tukey_taper(
             # around the object. We will construct the window, roll it to
             # expected object position, then roll t he taper
             search_mask = make_search_window(
-                x=delay_time.delay_time,
-                width_ns=tukey_tractor_options.peak_shift_seach_width_ns,
+                x=delay_time.delay,
+                width_ns=tukey_tractor_options.peak_shift_search_width_ns,
+            )
+            # Make the mask match t he shape of the data chunk. This is fine as the search width is
+            # constant across all baselines/dimensions (unlike the guard zone)
+            search_mask = np.broadcast_to(
+                search_mask, (object_idx.size, search_mask.size)
             )
             # Now roll the search window
             search_mask = apply_roll_for_taper(taper=search_mask, shifts=object_idx)
@@ -1051,7 +1056,7 @@ class TukeyTractorOptions(BaseOptions):
     """The minimum absolute flux an object should have (as measured in delay space in Jy) for it to be nulled"""
     peak_shift_search: bool = False
     """Search around the predicted delay for the peak in the delay spectrum to account for shifts (e.g. ionspheric shift, inaccuracies in prediction). """
-    peak_shift_seach_width_ns: float | None = None
+    peak_shift_search_width_ns: float | None = None
     """If provided this will be used to set strong limits to search for a peak around a predicted objects position. If None when peak search is activated, the taper is used in stead."""
 
 

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -743,16 +743,23 @@ def compute_tukey_taper(
             search_mask = np.broadcast_to(
                 search_mask, (object_idx.size, search_mask.size)
             )
+            # Rhw object idx is relative to the 0th element, but
+            # the search mask is orientated around 0-seconds, which could be anywhere
+            zero_idx = find_idx_of_closest_delay(
+                x=delay_time.delay,
+                object_delays=np.zeros_like(tukey_x_offset_sec) * u.s,
+            )
             # Now roll the search window
-            search_mask = apply_roll_for_taper(taper=search_mask, shifts=object_idx)
+            search_mask = apply_roll_for_taper(
+                taper=search_mask, shifts=object_idx - zero_idx
+            )
             # The mask should not be at the the object predicted position
-            logger.info(f"{search_mask.shape=}")
-            logger.info(f"{search_mask}")
             object_response = search_mask * stokes_i_delay
 
         # Now find the peak response and determine the shift
         peak_idx = np.argmax(object_response, axis=1)
         shifts = peak_idx - object_idx
+        logger.info(f"{shifts=}")
 
         taper = apply_roll_for_taper(taper=taper[..., 0], shifts=shifts)[..., None]
 

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -702,7 +702,7 @@ def compute_tukey_taper(
     taper = np.swapaxes(taper[:, :, None], 0, 1)
     # taper shape is [chunk_size, no_channels, no_pols]
 
-    stokes_i_delay: NDArray[complex[Any]] | None = None
+    stokes_i_delay: NDArray[np.complexfloating[Any]] | None = None
     if tukey_tractor_options.peak_shift_search:
         # This isolates the spectrum of the source in delay space
         inverted_taper = (1.0 - taper)[..., 0]

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -577,6 +577,50 @@ class TaperResult:
     """The delay_time taper was constructede against"""
 
 
+def find_idx_of_closest_delay(x: u.Quantity, object_delays: u.Quantity) -> NDArray[int]:
+    """Identify the index in `x` whose element's value is closest
+    to the items described in `object_delays`. The `x` remains
+    unchanged for all comparison through to `object_delays`.
+
+    Args:
+        x (u.Quantity): The array to search for the closest index of (e.g. the delay time spectrum)
+        object_delays (u.Quantity): The target values to find matches for
+
+    Returns:
+        NDArray[np.int]: The index into `x` where the is closest to values in `object_delays`
+    """
+    # Attempt to identify the closest idx in time
+    diffs = x[:, None] - object_delays[None, :]
+    diffs = np.abs(diffs)
+
+    return np.argmin(diffs, axis=0)
+
+
+def apply_roll_for_taper(
+    taper: NDArray[np.floating[Any]], shifts: NDArray[int]
+) -> NDArray[np.floating[Any]]:
+    """Roll the delay time of each row by a specified number of elements
+
+    The taper should be of shape (no_rows, no_delay_time). The n'th ``shits``
+    will be used to roll the delay time of the n'th row by that value
+
+    Args:
+        taper (NDArray[np.floating[Any]]): The taper to modified
+        shifts (NDArray[np.int]): The shifts to apply to the delay time for each row
+
+    Returns:
+        NDArray[np.floating[Any]]: The shifted taper
+    """
+
+    no_rows, no_times = taper.shape
+    time_indices = np.arange(no_times)
+    # Subtracting shifts moves elements to the right (standard roll behavior)
+    shifted_indices = (time_indices - shifts[:, np.newaxis]) % no_times
+
+    # 2. Use advanced indexing to construct the result
+    return taper[np.arange(no_rows)[:, np.newaxis], shifted_indices]
+
+
 def compute_tukey_taper(
     data_chunk: DataChunk,
     tukey_tractor_options: TukeyTractorOptions,
@@ -658,31 +702,29 @@ def compute_tukey_taper(
     taper = np.swapaxes(taper[:, :, None], 0, 1)
     # taper shape is [chunk_size, no_channels, no_pols]
 
+    stokes_i_delay: NDArray[complex[Any]] | None = None
     if tukey_tractor_options.peak_shift_search:
         # This isolates the spectrum of the source in delay space
-        tapered_response = np.abs(
-            np.sum(delay_time.delay_time[..., [0, -1]], axis=-1)
-        ) * (1.0 - taper[..., 0])
-        peak_idx = np.argmax(tapered_response, axis=1)
+        inverted_taper = (1.0 - taper)[..., 0]
+        # The formed stokes I spectrum code be reused later should
+        # comparisons to field or minimum flux cuts are applied
+        stokes_i_delay = np.sum(np.abs(delay_time.delay_time[..., [0, 3]]), axis=-1)
 
-        # Find the closest idx for the centered taper position
-        object_idx = np.argmin(
-            np.abs(
-                delay_time.delay.to("s").value[:, None]
-                - tukey_x_offset.to("s").value[None, :]
-            ),
-            axis=0,
+        # Here the taper is used to isolate the objects spectrum, and
+        # then we look for the peak. The taper should be reasonably well
+        # constructed to be in approximately the right location
+        object_response = inverted_taper * stokes_i_delay
+        peak_idx = np.argmax(object_response, axis=1)
+
+        # We have to get the closest element from the time and not the minimum of
+        # the taper as the taper can have a 'top hat' zero region
+        object_idx = find_idx_of_closest_delay(
+            x=delay_time.delay, object_delays=tukey_x_offset_sec * u.s
         )
-        shift_idx = object_idx - peak_idx
 
-        logger.info(f"{shift_idx=}")
-        logger.info(f"{shift_idx.shape=}")
+        shifts = peak_idx - object_idx
 
-        # and since the taper is smoothly verying and wrapped around the
-        # bounds we can roll it. May not be perfectly accurate at the
-        # sub-pixel level as taper is generated on the shifted/rotated
-        # coordinatre system, but good enough
-        taper = np.roll(taper, shift_idx, axis=1)
+        taper = apply_roll_for_taper(taper=taper[..., 0], shifts=shifts)[..., None]
 
     # apply the flags to ignore the tapering if the object is larger
     # than one wrap away
@@ -730,7 +772,11 @@ def compute_tukey_taper(
         # The delay spectrum are complex quantities, and we need to compare
         # the flux
         # Make a stokes I type spectrum
-        abs_delay_time = np.abs(np.sum(delay_time.delay_time[..., [0, -1]], axis=-1))
+        abs_delay_time = (
+            stokes_i_delay
+            if stokes_i_delay is not None
+            else np.abs(np.sum(delay_time.delay_time[..., [0, -1]], axis=-1))
+        )
 
         _field_taper = np.squeeze(field_taper)
         field_stats = np.max(abs_delay_time * (1.0 - _field_taper), axis=1)

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -658,6 +658,17 @@ def compute_tukey_taper(
     taper = np.swapaxes(taper[:, :, None], 0, 1)
     # taper shape is [chunk_size, no_channels, no_pols]
 
+    if tukey_tractor_options.peak_shift_search:
+        # This isolates the spectrum of the source in delay space
+        tapered_response = delay_time * (1.0 - taper)
+        peak_idx = np.argmax(tapered_response, axis=1)
+
+        # and since the taper is smoothly verying and wrapped around the
+        # bounds we can roll it. May not be perfectly accurate at the
+        # sub-pixel level as taper is generated on the shifted/rotated
+        # coordinatre system, but good enough
+        taper = np.roll(taper, peak_idx, axis=1)
+
     # apply the flags to ignore the tapering if the object is larger
     # than one wrap away
     # Calculate the offset account of nyquist sampling
@@ -954,6 +965,8 @@ class TukeyTractorOptions(BaseOptions):
     """The attenuation level of the main lobe to guard to, and should be in the range (0, 1). Values closer to zero correspond to a larger field-of-view, and hence a larger guard band in delay space. """
     object_minimum_flux: float | None = None
     """The minimum absolute flux an object should have (as measured in delay space in Jy) for it to be nulled"""
+    peak_shift_search: bool = False
+    """Search around the predicted delay for the peak in the delay spectrum to account for shifts (e.g. ionspheric shift, inaccuracies in prediction). """
 
 
 @dataclass(frozen=True)

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -571,7 +571,7 @@ class TaperResult:
     """The taper to apply. If None nothing to do."""
     update_flags: bool = False
     """Indicates whether flags need to be updated"""
-    flags: NDArray[bool] | None = None
+    flags: NDArray[np.bool_] | None = None
     """The fupdated flags"""
     delay_time: DelayTime | None = None
     """The delay_time taper was constructede against"""
@@ -797,7 +797,7 @@ class TaperedChunkResult:
     """The data to write back"""
     update_flags: bool = False
     """"Indicates whether the flags need to be written back to MS"""
-    flags: NDArray[bool] | None = None
+    flags: NDArray[np.bool_] | None = None
     """The flags to write back"""
     update_weights: bool = False
     """Indicates whether data should be written back to the MS"""

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -601,7 +601,7 @@ def apply_roll_for_taper(
 ) -> NDArray[np.floating[Any]]:
     """Roll the delay time of each row by a specified number of elements
 
-    The taper should be of shape (no_rows, no_delay_time). The n'th ``shits``
+    The taper should be of shape (no_rows, no_delay_time). The n'th ``shifts``
     will be used to roll the delay time of the n'th row by that value
 
     Args:

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -673,12 +673,16 @@ def compute_tukey_taper(
             ),
             axis=0,
         )
+        shift_idx = object_idx - peak_idx
+
+        logger.info(f"{shift_idx=}")
+        logger.info(f"{shift_idx.shape=}")
 
         # and since the taper is smoothly verying and wrapped around the
         # bounds we can roll it. May not be perfectly accurate at the
         # sub-pixel level as taper is generated on the shifted/rotated
         # coordinatre system, but good enough
-        taper = np.roll(taper, peak_idx - object_idx, axis=1)
+        taper = np.roll(taper, shift_idx, axis=1)
 
     # apply the flags to ignore the tapering if the object is larger
     # than one wrap away

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -621,6 +621,14 @@ def apply_roll_for_taper(
     return taper[np.arange(no_rows)[:, np.newaxis], shifted_indices]
 
 
+def make_search_window(x: u.Quantity, width_ns: float) -> NDArray[np.bool_]:
+    """Little helper to test to make sure that the guard window is
+    formed with Trues at center"""
+
+    delay_time_ns = x.to("s").value
+    return np.abs(delay_time_ns) < width_ns
+
+
 def compute_tukey_taper(
     data_chunk: DataChunk,
     tukey_tractor_options: TukeyTractorOptions,
@@ -704,24 +712,39 @@ def compute_tukey_taper(
 
     stokes_i_delay: NDArray[np.complexfloating[Any]] | None = None
     if tukey_tractor_options.peak_shift_search:
-        # This isolates the spectrum of the source in delay space
-        inverted_taper = (1.0 - taper)[..., 0]
         # The formed stokes I spectrum code be reused later should
         # comparisons to field or minimum flux cuts are applied
         stokes_i_delay = np.sum(np.abs(delay_time.delay_time[..., [0, 3]]), axis=-1)
-
-        # Here the taper is used to isolate the objects spectrum, and
-        # then we look for the peak. The taper should be reasonably well
-        # constructed to be in approximately the right location
-        object_response = inverted_taper * stokes_i_delay
-        peak_idx = np.argmax(object_response, axis=1)
-
         # We have to get the closest element from the time and not the minimum of
         # the taper as the taper can have a 'top hat' zero region
         object_idx = find_idx_of_closest_delay(
             x=delay_time.delay, object_delays=tukey_x_offset_sec * u.s
         )
 
+        if tukey_tractor_options.peak_shift_seach_width_ns is None:
+            # This isolates the spectrum of the source in delay space
+            inverted_taper = (1.0 - taper)[..., 0]
+
+            # Here the taper is used to isolate the objects spectrum, and
+            # then we look for the peak. The taper should be reasonably well
+            # constructed to be in approximately the right location
+            object_response = inverted_taper * stokes_i_delay
+
+        else:
+            # a strict window has been provided that will be used to search
+            # around the object. We will construct the window, roll it to
+            # expected object position, then roll t he taper
+            search_mask = make_search_window(
+                x=delay_time.delay_time,
+                width_ns=tukey_tractor_options.peak_shift_seach_width_ns,
+            )
+            # Now roll the search window
+            search_mask = apply_roll_for_taper(taper=search_mask, shifts=object_idx)
+            # The mask should not be at the the object predicted position
+            object_response = search_mask * stokes_i_delay
+
+        # Now find the peak response and determine the shift
+        peak_idx = np.argmax(object_response, axis=1)
         shifts = peak_idx - object_idx
 
         taper = apply_roll_for_taper(taper=taper[..., 0], shifts=shifts)[..., None]
@@ -1028,6 +1051,8 @@ class TukeyTractorOptions(BaseOptions):
     """The minimum absolute flux an object should have (as measured in delay space in Jy) for it to be nulled"""
     peak_shift_search: bool = False
     """Search around the predicted delay for the peak in the delay spectrum to account for shifts (e.g. ionspheric shift, inaccuracies in prediction). """
+    peak_shift_seach_width_ns: float | None = None
+    """If provided this will be used to set strong limits to search for a peak around a predicted objects position. If None when peak search is activated, the taper is used in stead."""
 
 
 @dataclass(frozen=True)

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -660,7 +660,9 @@ def compute_tukey_taper(
 
     if tukey_tractor_options.peak_shift_search:
         # This isolates the spectrum of the source in delay space
-        tapered_response = delay_time * (1.0 - taper)
+        tapered_response = np.abs(
+            np.sum(delay_time.delay_time[..., [0, -1]], axis=-1)
+        ) * (1.0 - taper)
         peak_idx = np.argmax(tapered_response, axis=1)
 
         # and since the taper is smoothly verying and wrapped around the

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -772,15 +772,15 @@ def compute_tukey_taper(
         # The delay spectrum are complex quantities, and we need to compare
         # the flux
         # Make a stokes I type spectrum
-        abs_delay_time = (
-            stokes_i_delay
-            if stokes_i_delay is not None
-            else np.abs(np.sum(delay_time.delay_time[..., [0, -1]], axis=-1))
-        )
+
+        if stokes_i_delay is None:
+            stokes_i_delay = np.abs(
+                np.sum(delay_time.delay_time[..., [0, -1]], axis=-1)
+            )
 
         _field_taper = np.squeeze(field_taper)
-        field_stats = np.max(abs_delay_time * (1.0 - _field_taper), axis=1)
-        object_stats = np.max(abs_delay_time * (1.0 - taper[..., 0]), axis=1)
+        field_stats = np.max(stokes_i_delay * (1.0 - _field_taper), axis=1)
+        object_stats = np.max(stokes_i_delay * (1.0 - taper[..., 0]), axis=1)
 
         if tukey_tractor_options.compare_to_field is not None:
             flux_mask = (

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -625,7 +625,7 @@ def make_search_window(x: u.Quantity, width_ns: float) -> NDArray[np.bool_]:
     """Little helper to test to make sure that the guard window is
     formed with Trues at center"""
 
-    delay_time_ns = x.to("s").value
+    delay_time_ns = x.to("ns").value
     return np.abs(delay_time_ns) < width_ns
 
 
@@ -746,6 +746,8 @@ def compute_tukey_taper(
             # Now roll the search window
             search_mask = apply_roll_for_taper(taper=search_mask, shifts=object_idx)
             # The mask should not be at the the object predicted position
+            logger.info(f"{search_mask.shape=}")
+            logger.info(f"{search_mask}")
             object_response = search_mask * stokes_i_delay
 
         # Now find the peak response and determine the shift

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -662,14 +662,23 @@ def compute_tukey_taper(
         # This isolates the spectrum of the source in delay space
         tapered_response = np.abs(
             np.sum(delay_time.delay_time[..., [0, -1]], axis=-1)
-        ) * (1.0 - taper)
+        ) * (1.0 - taper[..., 0])
         peak_idx = np.argmax(tapered_response, axis=1)
+
+        # Find the closest idx for the centered taper position
+        object_idx = np.argmin(
+            np.abs(
+                delay_time.delay.to("s").value[:, None]
+                - tukey_x_offset.to("s").value[None, :]
+            ),
+            axis=0,
+        )
 
         # and since the taper is smoothly verying and wrapped around the
         # bounds we can roll it. May not be perfectly accurate at the
         # sub-pixel level as taper is generated on the shifted/rotated
         # coordinatre system, but good enough
-        taper = np.roll(taper, peak_idx, axis=1)
+        taper = np.roll(taper, peak_idx - object_idx, axis=1)
 
     # apply the flags to ignore the tapering if the object is larger
     # than one wrap away

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -27,14 +27,14 @@ from jolly_roger.uvws import WDelays
 def test_make_search_window() -> None:
     """Perform a very simple check to ensure that the window function performs
     correctly"""
-    times = (np.arange(200) - 100) * u.s
+    times = (np.arange(200) - 100) * 1e-9 * u.s
     width_ns = 10
 
     mask = make_search_window(x=times, width_ns=width_ns)
-    assert np.sum(mask) == 19
-    assert np.all(~mask[:91])
-    assert np.all(mask[91 : 91 + 19])
-    assert np.all(~mask[91 + 19 :])
+    assert np.sum(mask) == 21
+    assert np.all(~mask[:90])
+    assert np.all(mask[90 : 90 + 21])
+    assert np.all(~mask[90 + 21 :])
 
 
 def test_apply_roll_for_taper() -> None:

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -18,9 +18,23 @@ from jolly_roger.tractor import (
     apply_roll_for_taper,
     compute_tukey_multi_taper,
     find_idx_of_closest_delay,
+    make_search_window,
     tukey_tractor,
 )
 from jolly_roger.uvws import WDelays
+
+
+def test_make_search_window() -> None:
+    """Perform a very simple check to ensure that the window function performs
+    correctly"""
+    times = (np.arange(200) - 100) * u.s
+    width_ns = 10
+
+    mask = make_search_window(x=times, width_ns=width_ns)
+    assert np.sum(mask) == 19
+    assert np.all(~mask[:91])
+    assert np.all(mask[91 : 91 + 19])
+    assert np.all(~mask[91 + 19 :])
 
 
 def test_apply_roll_for_taper() -> None:

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -65,6 +65,37 @@ def test_find_idx_of_closest_delay() -> None:
     assert idxs[1] == 189
 
 
+def test_tractor_run1_with_peak_search_and_width(ms_example) -> None:
+    """A very simple end-to-end test identifying crashes. This
+    invokes the peak search mode"""
+
+    new_column = "JACKS_DATA"
+
+    tukey_tractor_options = TukeyTractorOptions(
+        auto_size=False,
+        output_column=new_column,
+        peak_shift_search=True,
+        peak_shift_search_width_ns=20,
+        ignore_nyquist_zone=1000,
+        elevation_cut_deg=-100,
+        tukey_width_ns=20,
+        outer_width_ns=30,
+    )
+    with table(str(ms_example), ack=False) as tab:
+        cols = tab.colnames()
+        assert new_column not in cols
+
+    tractor_results = tukey_tractor(
+        ms_path=Path(ms_example),
+        tukey_tractor_options=tukey_tractor_options,
+    )
+
+    assert tractor_results.output_plots is None
+    with table(str(ms_example), ack=False) as tab:
+        cols = tab.colnames()
+        assert new_column in cols
+
+
 def test_tractor_run1_with_peak_search(ms_example) -> None:
     """A very simple end-to-end test identifying crashes. This
     invokes the peak search mode"""

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -15,10 +15,40 @@ from numpy import ma
 from jolly_roger.tractor import (
     DataChunk,
     TukeyTractorOptions,
+    apply_roll_for_taper,
     compute_tukey_multi_taper,
+    find_idx_of_closest_delay,
     tukey_tractor,
 )
 from jolly_roger.uvws import WDelays
+
+
+def test_apply_roll_for_taper() -> None:
+    """Ensure that a roll can be made over the delay time
+    axis, where the taper shape is (row, demay_time)"""
+
+    base = np.array(
+        [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]
+    )
+    shifts = np.array([0, 1, 2, 3])
+    shifted = np.array(
+        [[1, 2, 3, 4, 5], [10, 6, 7, 8, 9], [14, 15, 11, 12, 13], [18, 19, 20, 16, 17]]
+    )
+
+    rolled = apply_roll_for_taper(taper=base, shifts=shifts)
+    assert np.all(rolled == shifted)
+
+
+def test_find_idx_of_closest_delay() -> None:
+    """Given a delay domain, confirm that the correct index is returned
+    when attempting to find the closest"""
+    x = np.linspace(-100, 100, 200) * u.s
+    object = np.array((-90, 90)) * u.s
+
+    idxs = find_idx_of_closest_delay(x=x, object_delays=object)
+    assert len(idxs) == 2
+    assert idxs[0] == 10
+    assert idxs[1] == 189
 
 
 def test_tractor_run1_with_peak_search(ms_example) -> None:

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -21,6 +21,36 @@ from jolly_roger.tractor import (
 from jolly_roger.uvws import WDelays
 
 
+def test_tractor_run1_with_peak_search(ms_example) -> None:
+    """A very simple end-to-end test identifying crashes. This
+    invokes the peak search mode"""
+
+    new_column = "JACKS_DATA"
+
+    tukey_tractor_options = TukeyTractorOptions(
+        auto_size=False,
+        output_column=new_column,
+        peak_shift_search=True,
+        ignore_nyquist_zone=1000,
+        elevation_cut_deg=-100,
+        tukey_width_ns=20,
+        outer_width_ns=30,
+    )
+    with table(str(ms_example), ack=False) as tab:
+        cols = tab.colnames()
+        assert new_column not in cols
+
+    tractor_results = tukey_tractor(
+        ms_path=Path(ms_example),
+        tukey_tractor_options=tukey_tractor_options,
+    )
+
+    assert tractor_results.output_plots is None
+    with table(str(ms_example), ack=False) as tab:
+        cols = tab.colnames()
+        assert new_column in cols
+
+
 def test_tractor_run1(ms_example) -> None:
     """A very simple end-to-end test identifying crashes"""
 


### PR DESCRIPTION
In this PR I introduce a routine to search for a the peak of an object in ddelay space, and then roll the taper to that pixel. 

Our prediction of the objects delay is based on our recomputed (u,v,w)'s. These are not perfectly matched to those in the measurement set. Further, there are other known issues we don't currently consider that could led to the actual object being slightly off from the predicted delay. 

This routing will search of the peak delay by forming an 'apparentl object delay' spectrum:

```
object_delay = stokes_i_delay * (1. - taper)
```

The taper would normally null the objects contribution. Taking the inversion here instead isolates it. If the taper is ball park correct and the offset peak is bright enough to cause issues, then search it `argmax` style ought to be good enough. Once the shift is found then we roll the taper. Since the taper is constructed over the wrapped domain and is smoothly varying across this bounds, there is no problem with the roll. 

In a future PR we can extend this behaviour to search within a fixede window, optionally defined with a separate CLI that defines the window size in nanoseconds. The bits and pieces are there to support that now. 