### PR TITLE
Add shift guard

### DIFF
--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -738,14 +738,6 @@ def compute_tukey_taper(
             x=delay_time.delay, object_delays=tukey_x_offset_sec * u.s
         )
 
-        # The search must never look inside the protected field/guard region
-        # around delay 0, otherwise the peak can lock onto the field itself.
-        # This is folded into the search window by construction below.
-        outside_field = ~(
-            np.abs(delay_time.delay.to("s").value)[None, :]
-            < np.atleast_1d(field_outer_width)[:, None]
-        )
-
         if tukey_tractor_options.peak_shift_search_width_ns is None:
             # This isolates the spectrum of the source in delay space
             inverted_taper = (1.0 - taper)[..., 0]
@@ -753,7 +745,7 @@ def compute_tukey_taper(
             # Here the taper is used to isolate the objects spectrum, and
             # then we look for the peak. The taper should be reasonably well
             # constructed to be in approximately the right location
-            object_response = inverted_taper * outside_field * stokes_i_delay
+            object_response = inverted_taper * stokes_i_delay
 
         else:
             # a strict window has been provided that will be used to search
@@ -779,7 +771,7 @@ def compute_tukey_taper(
                 taper=search_mask, shifts=object_idx - zero_idx
             )
             # The mask should not be at the the object predicted position
-            object_response = search_mask * outside_field * stokes_i_delay
+            object_response = search_mask * stokes_i_delay
 
         # Now find the peak response and determine the shift
         peak_idx = np.argmax(object_response, axis=1)
@@ -787,8 +779,8 @@ def compute_tukey_taper(
 
         # Detection against the field is opt-in via compare_to_field: only then
         # do we refuse to move the null unless the in-window peak out-shines the
-        # field. Without it the peak search is unguarded (but still never looks
-        # inside the field/guard region).
+        # field. Without it the peak search is unguarded and a faint object can
+        # let the null lock onto the field itself.
         if tukey_tractor_options.compare_to_field is not None:
             field_stats = np.max(stokes_i_delay * (1.0 - field_taper[..., 0]), axis=1)
             object_peak = np.max(object_response, axis=1)
@@ -822,6 +814,11 @@ def compute_tukey_taper(
     intersecting_taper = np.any(
         np.reshape((taper != 1) & (field_taper != 1), (taper.shape[0], -1)), axis=1
     )
+
+    # The guard region protects the field's main lobe: we flag the crossing
+    # above, but never null inside it. Clamp the object taper back to 1 wherever
+    # the field taper is active so the field data itself is left untouched.
+    taper = np.where(field_taper != 1, 1.0, taper)
 
     # Here we consider what to do if want to compare brightness of the object in delay
     # space is less than that of the field. If the object is not detected we ought to

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -710,6 +710,23 @@ def compute_tukey_taper(
     taper = np.swapaxes(taper[:, :, None], 0, 1)
     # taper shape is [chunk_size, no_channels, no_pols]
 
+    # The field null (delay 0) taper is needed both to gate the peak search
+    # below and to compute the object/field crossing flags further down.
+    field_outer_width = tukey_tractor_options.outer_width_ns * 1e-9
+    if w_delays.guard_region is not None:
+        field_outer_width += w_delays.guard_region[baseline_idx, time_idx].to("s").value
+
+    field_taper = get_2d_taper(
+        x=delay_time.delay.to("s").value,
+        outer_width=field_outer_width,
+        tukey_width=tukey_tractor_options.tukey_width_ns * 1e-9,
+        tukey_offset=None,
+    )
+    # field_taper.shape is [no_channels, ]
+    # We need to account for no broadcasting when offset is None
+    # as the returned shape is different
+    field_taper = np.swapaxes(field_taper[:, :, None], 0, 1)
+
     stokes_i_delay: NDArray[np.complexfloating[Any]] | None = None
     if tukey_tractor_options.peak_shift_search:
         # The formed stokes I spectrum code be reused later should
@@ -756,9 +773,32 @@ def compute_tukey_taper(
             # The mask should not be at the the object predicted position
             object_response = search_mask * stokes_i_delay
 
+        # Exclude the field null at delay 0 so the argmax cannot lock onto the
+        # field where the source is fainter than the field.
+        field_null = (
+            np.abs(delay_time.delay.to("s").value)[None, :]
+            < np.atleast_1d(field_outer_width)[:, None]
+        )
+        object_response = np.where(field_null, 0.0, object_response)
+
         # Now find the peak response and determine the shift
         peak_idx = np.argmax(object_response, axis=1)
-        shifts = peak_idx - object_idx
+
+        # Only move the null off the predicted delay where the in-window peak is
+        # a genuine detection against the field, reusing the compare_to_field
+        # criterion. Without it the null would just lock onto in-window noise.
+        # When compare_to_field is unset the factor defaults to 1.0, i.e. the
+        # peak must out-shine the field to be accepted.
+        field_stats = np.max(stokes_i_delay * (1.0 - field_taper[..., 0]), axis=1)
+        object_peak = np.max(object_response, axis=1)
+        compare_factor = (
+            tukey_tractor_options.compare_to_field
+            if tukey_tractor_options.compare_to_field is not None
+            else 1.0
+        )
+        detected = object_peak >= compare_factor * field_stats
+
+        shifts = np.where(detected, peak_idx - object_idx, 0)
         logger.info(f"{shifts=}")
 
         taper = apply_roll_for_taper(taper=taper[..., 0], shifts=shifts)[..., None]
@@ -780,21 +820,7 @@ def compute_tukey_taper(
     # Compute flags to ignore the objects delay crossing 0, Do
     # This by computing the taper towards the field and
     # see if there are any components of the two sets of tapers
-    # that are not 1 (where 1 is 'no change').
-    field_outer_width = tukey_tractor_options.outer_width_ns * 1e-9
-    if w_delays.guard_region is not None:
-        field_outer_width += w_delays.guard_region[baseline_idx, time_idx].to("s").value
-
-    field_taper = get_2d_taper(
-        x=delay_time.delay.to("s").value,
-        outer_width=field_outer_width,
-        tukey_width=tukey_tractor_options.tukey_width_ns * 1e-9,
-        tukey_offset=None,
-    )
-    # field_taper.shape is [no_channels, ]
-    # We need to account for no broadcasting when offset is None
-    # as the returned shape is different
-    field_taper = np.swapaxes(field_taper[:, :, None], 0, 1)
+    # that are not 1 (where 1 is 'no change'). ``field_taper`` was formed above.
     intersecting_taper = np.any(
         np.reshape((taper != 1) & (field_taper != 1), (taper.shape[0], -1)), axis=1
     )

--- a/jolly_roger/tractor.py
+++ b/jolly_roger/tractor.py
@@ -738,6 +738,14 @@ def compute_tukey_taper(
             x=delay_time.delay, object_delays=tukey_x_offset_sec * u.s
         )
 
+        # The search must never look inside the protected field/guard region
+        # around delay 0, otherwise the peak can lock onto the field itself.
+        # This is folded into the search window by construction below.
+        outside_field = ~(
+            np.abs(delay_time.delay.to("s").value)[None, :]
+            < np.atleast_1d(field_outer_width)[:, None]
+        )
+
         if tukey_tractor_options.peak_shift_search_width_ns is None:
             # This isolates the spectrum of the source in delay space
             inverted_taper = (1.0 - taper)[..., 0]
@@ -745,7 +753,7 @@ def compute_tukey_taper(
             # Here the taper is used to isolate the objects spectrum, and
             # then we look for the peak. The taper should be reasonably well
             # constructed to be in approximately the right location
-            object_response = inverted_taper * stokes_i_delay
+            object_response = inverted_taper * outside_field * stokes_i_delay
 
         else:
             # a strict window has been provided that will be used to search
@@ -771,34 +779,24 @@ def compute_tukey_taper(
                 taper=search_mask, shifts=object_idx - zero_idx
             )
             # The mask should not be at the the object predicted position
-            object_response = search_mask * stokes_i_delay
-
-        # Exclude the field null at delay 0 so the argmax cannot lock onto the
-        # field where the source is fainter than the field.
-        field_null = (
-            np.abs(delay_time.delay.to("s").value)[None, :]
-            < np.atleast_1d(field_outer_width)[:, None]
-        )
-        object_response = np.where(field_null, 0.0, object_response)
+            object_response = search_mask * outside_field * stokes_i_delay
 
         # Now find the peak response and determine the shift
         peak_idx = np.argmax(object_response, axis=1)
+        shifts = peak_idx - object_idx
 
-        # Only move the null off the predicted delay where the in-window peak is
-        # a genuine detection against the field, reusing the compare_to_field
-        # criterion. Without it the null would just lock onto in-window noise.
-        # When compare_to_field is unset the factor defaults to 1.0, i.e. the
-        # peak must out-shine the field to be accepted.
-        field_stats = np.max(stokes_i_delay * (1.0 - field_taper[..., 0]), axis=1)
-        object_peak = np.max(object_response, axis=1)
-        compare_factor = (
-            tukey_tractor_options.compare_to_field
-            if tukey_tractor_options.compare_to_field is not None
-            else 1.0
-        )
-        detected = object_peak >= compare_factor * field_stats
+        # Detection against the field is opt-in via compare_to_field: only then
+        # do we refuse to move the null unless the in-window peak out-shines the
+        # field. Without it the peak search is unguarded (but still never looks
+        # inside the field/guard region).
+        if tukey_tractor_options.compare_to_field is not None:
+            field_stats = np.max(stokes_i_delay * (1.0 - field_taper[..., 0]), axis=1)
+            object_peak = np.max(object_response, axis=1)
+            detected = (
+                object_peak >= tukey_tractor_options.compare_to_field * field_stats
+            )
+            shifts = np.where(detected, shifts, 0)
 
-        shifts = np.where(detected, peak_idx - object_idx, 0)
         logger.info(f"{shifts=}")
 
         taper = apply_roll_for_taper(taper=taper[..., 0], shifts=shifts)[..., None]

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -300,33 +300,10 @@ def _delay_amp(
     return float(np.abs(delay_time.delay_time[:, window, 0]).max())
 
 
-def test_peak_shift_search_tracks_bright_ignores_faint() -> None:
-    """The peak search should null a source that out-shines the field, but fall
-    back to the predicted position (leaving the source alone) when the in-window
-    peak is fainter than the field."""
-    n_time, source_ns = 4, 80.0
-    options = TukeyTractorOptions(
-        outer_width_ns=40.0,
-        tukey_width_ns=10.0,
-        peak_shift_search=True,
-        peak_shift_search_width_ns=120.0,
-    )
-
-    bright, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=10.0)
-    result = compute_tukey_multi_taper(
-        bright, options, [_predict_field_wdelays(n_time)]
-    )
-    assert _delay_amp(result.data_chunk, delay_ns, source_ns) < 0.1
-
-    faint, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=0.1)
-    result = compute_tukey_multi_taper(faint, options, [_predict_field_wdelays(n_time)])
-    assert _delay_amp(result.data_chunk, delay_ns, source_ns) > 0.05
-
-
-def test_peak_shift_search_excludes_guard_band() -> None:
-    """A bright source sitting inside a protected guard band must not pull the
-    null off the field: with the guard set it is excluded from the search and
-    the shift falls back to the predicted position."""
+def test_peak_shift_search_tracks_bright_source() -> None:
+    """A source that out-shines the field is found in the search window and the
+    null is moved onto it, sparing the field at delay 0. No detection opt-in is
+    required for a genuine shift."""
     n_time, source_ns = 4, 80.0
     options = TukeyTractorOptions(
         outer_width_ns=40.0,
@@ -338,7 +315,47 @@ def test_peak_shift_search_excludes_guard_band() -> None:
     chunk, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=10.0)
     result = compute_tukey_multi_taper(chunk, options, [_predict_field_wdelays(n_time)])
     assert _delay_amp(result.data_chunk, delay_ns, source_ns) < 0.1
+    assert _delay_amp(result.data_chunk, delay_ns, 0.0) > 0.5
 
+
+def test_peak_shift_search_compare_to_field_ignores_faint() -> None:
+    """With compare_to_field opted in, a source fainter than the field is not a
+    detection, so the shift falls back to the predicted position: the field is
+    nulled and the faint source is left alone."""
+    n_time, source_ns = 4, 80.0
+    options = TukeyTractorOptions(
+        outer_width_ns=40.0,
+        tukey_width_ns=10.0,
+        peak_shift_search=True,
+        peak_shift_search_width_ns=120.0,
+        compare_to_field=0.2,
+    )
+
+    chunk, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=0.1)
+    result = compute_tukey_multi_taper(chunk, options, [_predict_field_wdelays(n_time)])
+    assert _delay_amp(result.data_chunk, delay_ns, source_ns) > 0.05
+    assert _delay_amp(result.data_chunk, delay_ns, 0.0) < 0.1
+
+
+def test_peak_shift_search_excludes_guard_band() -> None:
+    """The search must never look inside the guard band. A bright source that
+    would otherwise be nulled is spared once a guard band covers it, because it
+    is excluded from the search by construction (no detection opt-in involved)."""
+    n_time, source_ns = 4, 60.0
+    options = TukeyTractorOptions(
+        outer_width_ns=40.0,
+        tukey_width_ns=10.0,
+        peak_shift_search=True,
+        peak_shift_search_width_ns=120.0,
+    )
+
+    # No guard: the source sits outside the field null, is found, and is nulled.
+    chunk, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=10.0)
+    result = compute_tukey_multi_taper(chunk, options, [_predict_field_wdelays(n_time)])
+    assert _delay_amp(result.data_chunk, delay_ns, source_ns) < 0.1
+
+    # Guard band covering the source: the search cannot see it, so the null is
+    # never pulled onto it and the source survives.
     chunk, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=10.0)
     result = compute_tukey_multi_taper(
         chunk, options, [_predict_field_wdelays(n_time, guard_ns=60.0)]

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -318,10 +318,30 @@ def test_peak_shift_search_tracks_bright_source() -> None:
     assert _delay_amp(result.data_chunk, delay_ns, 0.0) > 0.5
 
 
+def test_peak_shift_search_flags_object_over_field() -> None:
+    """When the object is predicted onto the field at delay 0 the crossing must
+    be flagged, and the field data must be preserved (never nulled in the guard
+    region). This is the default path with no detection opt-in."""
+    n_time = 4
+    options = TukeyTractorOptions(
+        outer_width_ns=40.0,
+        tukey_width_ns=10.0,
+        peak_shift_search=True,
+        peak_shift_search_width_ns=120.0,
+    )
+
+    chunk, delay_ns = _peak_search_chunk(source_ns=0.0, source_amp=0.0)
+    result = compute_tukey_multi_taper(chunk, options, [_predict_field_wdelays(n_time)])
+    assert result.flags is not None
+    assert result.flags[:, :, 0].all()
+    assert _delay_amp(result.data_chunk, delay_ns, 0.0) > 0.5
+
+
 def test_peak_shift_search_compare_to_field_ignores_faint() -> None:
     """With compare_to_field opted in, a source fainter than the field is not a
-    detection, so the shift falls back to the predicted position: the field is
-    nulled and the faint source is left alone."""
+    detection, so the shift falls back to the predicted position over the field:
+    the crossing is flagged, the field is preserved, and the faint source is
+    left alone."""
     n_time, source_ns = 4, 80.0
     options = TukeyTractorOptions(
         outer_width_ns=40.0,
@@ -333,14 +353,17 @@ def test_peak_shift_search_compare_to_field_ignores_faint() -> None:
 
     chunk, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=0.1)
     result = compute_tukey_multi_taper(chunk, options, [_predict_field_wdelays(n_time)])
+    assert result.flags is not None
+    assert result.flags[:, :, 0].all()
     assert _delay_amp(result.data_chunk, delay_ns, source_ns) > 0.05
-    assert _delay_amp(result.data_chunk, delay_ns, 0.0) < 0.1
+    assert _delay_amp(result.data_chunk, delay_ns, 0.0) > 0.5
 
 
-def test_peak_shift_search_excludes_guard_band() -> None:
-    """The search must never look inside the guard band. A bright source that
-    would otherwise be nulled is spared once a guard band covers it, because it
-    is excluded from the search by construction (no detection opt-in involved)."""
+def test_peak_shift_search_never_nulls_guard_band() -> None:
+    """The object null is never applied inside the guard region. A bright source
+    outside the field null is nulled normally, but once a guard band covers it
+    the null is clamped away and the source survives (the crossing is flagged
+    instead)."""
     n_time, source_ns = 4, 60.0
     options = TukeyTractorOptions(
         outer_width_ns=40.0,
@@ -354,12 +377,14 @@ def test_peak_shift_search_excludes_guard_band() -> None:
     result = compute_tukey_multi_taper(chunk, options, [_predict_field_wdelays(n_time)])
     assert _delay_amp(result.data_chunk, delay_ns, source_ns) < 0.1
 
-    # Guard band covering the source: the search cannot see it, so the null is
-    # never pulled onto it and the source survives.
+    # Guard band covering the source: the null is clamped out of the guard, so
+    # the source survives and the row is flagged instead.
     chunk, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=10.0)
     result = compute_tukey_multi_taper(
         chunk, options, [_predict_field_wdelays(n_time, guard_ns=60.0)]
     )
+    assert result.flags is not None
+    assert result.flags[:, :, 0].all()
     assert _delay_amp(result.data_chunk, delay_ns, source_ns) > 5.0
 
 

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -11,7 +11,9 @@ from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from casacore.tables import table
 from numpy import ma
+from numpy.typing import NDArray
 
+from jolly_roger.delays import data_to_delay_time
 from jolly_roger.tractor import (
     DataChunk,
     TukeyTractorOptions,
@@ -230,6 +232,118 @@ def test_compute_tukey_multi_taper_applies_taper() -> None:
     assert result.update_data
     assert result.data_chunk is not None
     assert result.data_chunk.masked_data.shape == data_chunk.masked_data.shape
+
+
+def _peak_search_chunk(
+    source_ns: float,
+    source_amp: float,
+    field_amp: float = 1.0,
+    n_time: int = 4,
+    n_chan: int = 256,
+    n_pol: int = 4,
+) -> tuple[DataChunk, NDArray[np.floating]]:
+    """A single-baseline chunk with a field peak at delay 0 and an optional
+    source peak at ``source_ns``, built directly in delay space (matching
+    ``data_to_delay_time``'s forward transform)."""
+    freq_chan = np.linspace(744, 1032, n_chan) * u.MHz
+    delay_ns = (
+        np.fft.fftshift(np.fft.fftfreq(n_chan, d=np.diff(freq_chan).mean()).decompose())
+        .to(u.ns)
+        .value
+    )
+    delay_space = np.zeros((n_time, n_chan), dtype=complex)
+    delay_space[:, np.abs(delay_ns).argmin()] += field_amp
+    if source_amp:
+        delay_space[:, np.abs(delay_ns - source_ns).argmin()] += source_amp
+    vis = np.fft.ifft(np.fft.ifftshift(delay_space, axes=1), axis=1, norm="forward")
+
+    chunk = DataChunk(
+        masked_data=ma.masked_array(
+            vis[..., None].repeat(n_pol, -1),
+            mask=np.zeros((n_time, n_chan, n_pol), dtype=bool),
+        ),
+        freq_chan=freq_chan,
+        phase_center=SkyCoord(ra=0.0 * u.deg, dec=0.0 * u.deg),
+        uvws_phase_center=np.zeros((n_time, 3)) * u.m,
+        time=Time.now(),
+        time_mjds=np.arange(n_time, dtype=float),
+        ant_1=np.zeros(n_time, dtype=np.int64),
+        ant_2=np.ones(n_time, dtype=np.int64),
+        row_start=0,
+        chunk_size=n_time,
+    )
+    return chunk, delay_ns
+
+
+def _predict_field_wdelays(n_time: int, guard_ns: float | None = None) -> WDelays:
+    """WDelays predicting the object at delay 0 (the field), optionally with a
+    protected guard band of half-width ``guard_ns``."""
+    guard = None if guard_ns is None else np.full((1, n_time), guard_ns * 1e-9) * u.s
+    return WDelays(
+        object_name="drifter",
+        w_delays=np.zeros((1, n_time)) * u.s,
+        b_map={(0, 1): 0},
+        time_map={t * u.s: idx for idx, t in enumerate(np.arange(n_time, dtype=float))},
+        elevation=np.full(n_time, 90.0) * u.deg,
+        guard_region=guard,
+    )
+
+
+def _delay_amp(
+    chunk: DataChunk | None, delay_ns: NDArray[np.floating], target_ns: float
+) -> float:
+    """Peak |delay spectrum| (pol 0) in a small window around ``target_ns``."""
+    assert chunk is not None
+    delay_time = data_to_delay_time(chunk)
+    bin_idx = int(np.abs(delay_ns - target_ns).argmin())
+    window = slice(bin_idx - 2, bin_idx + 3)
+    return float(np.abs(delay_time.delay_time[:, window, 0]).max())
+
+
+def test_peak_shift_search_tracks_bright_ignores_faint() -> None:
+    """The peak search should null a source that out-shines the field, but fall
+    back to the predicted position (leaving the source alone) when the in-window
+    peak is fainter than the field."""
+    n_time, source_ns = 4, 80.0
+    options = TukeyTractorOptions(
+        outer_width_ns=40.0,
+        tukey_width_ns=10.0,
+        peak_shift_search=True,
+        peak_shift_search_width_ns=120.0,
+    )
+
+    bright, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=10.0)
+    result = compute_tukey_multi_taper(
+        bright, options, [_predict_field_wdelays(n_time)]
+    )
+    assert _delay_amp(result.data_chunk, delay_ns, source_ns) < 0.1
+
+    faint, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=0.1)
+    result = compute_tukey_multi_taper(faint, options, [_predict_field_wdelays(n_time)])
+    assert _delay_amp(result.data_chunk, delay_ns, source_ns) > 0.05
+
+
+def test_peak_shift_search_excludes_guard_band() -> None:
+    """A bright source sitting inside a protected guard band must not pull the
+    null off the field: with the guard set it is excluded from the search and
+    the shift falls back to the predicted position."""
+    n_time, source_ns = 4, 80.0
+    options = TukeyTractorOptions(
+        outer_width_ns=40.0,
+        tukey_width_ns=10.0,
+        peak_shift_search=True,
+        peak_shift_search_width_ns=120.0,
+    )
+
+    chunk, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=10.0)
+    result = compute_tukey_multi_taper(chunk, options, [_predict_field_wdelays(n_time)])
+    assert _delay_amp(result.data_chunk, delay_ns, source_ns) < 0.1
+
+    chunk, delay_ns = _peak_search_chunk(source_ns=source_ns, source_amp=10.0)
+    result = compute_tukey_multi_taper(
+        chunk, options, [_predict_field_wdelays(n_time, guard_ns=60.0)]
+    )
+    assert _delay_amp(result.data_chunk, delay_ns, source_ns) > 5.0
 
 
 def test_compute_tukey_multi_taper_skips_below_elevation_cut() -> None:


### PR DESCRIPTION
I noticed a slightly unexpected behaviour when using the new `peak_shift_search` option - more data was being flagged. I looks like when the shifted region is sufficiently close to the 0-delay region the 0-delay track can be picked for nulling over the actual target.

This PR adds two primary changes
- Excludes the guard region from being shifted to
- Exposes the `compare_to_field` option to the shift stats when activated

Edit:
Turns out some extra flagging is to be expected it seems. However, some extra guards on the 0-delay region are still warranted